### PR TITLE
Fix #400: move autoloader to src/Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See the examples/ directory for examples of the key client features.
 ```PHP
 <?php
 
-  require_once 'google-api-php-client/autoload.php'; // or wherever autoload.php is located
+  require_once 'google-api-php-client/src/Google/autoload.php'; // or wherever autoload.php is located
   
   $client = new Google_Client();
   $client->setApplicationName("Client_Library_Examples");

--- a/autoload.php
+++ b/autoload.php
@@ -15,19 +15,12 @@
  * limitations under the License.
  */
 
-function google_api_php_client_autoload($className) {
-  $classPath = explode('_', $className);
-  if ($classPath[0] != 'Google') {
-    return;
-  }
-  if (count($classPath) > 3) {
-    // Maximum class file path depth in this project is 3.
-    $classPath = array_slice($classPath, 0, 3);
-  }
-  $filePath = dirname(__FILE__) . '/src/' . implode('/', $classPath) . '.php';
-  if (file_exists($filePath)) {
-    require_once($filePath);
-  }
+// PHP 5.2 compatibility: E_USER_DEPRECATED was added in 5.3
+if (!defined('E_USER_DEPRECATED')) {
+  define('E_USER_DEPRECATED', E_USER_WARNING);
 }
 
-spl_autoload_register('google_api_php_client_autoload');
+$error = "google-api-php-client's autoloader was moved to src/Google/autoload.php in 1.1.3. This ";
+$error .= "redirect will be removed in 1.2. Please adjust your code to use the new location.";
+trigger_error($error, E_USER_DEPRECATED);
+require_once 'src/Google/autoload.php';

--- a/examples/appengineauth.php
+++ b/examples/appengineauth.php
@@ -21,7 +21,7 @@ include_once "templates/base.php";
   Make an API request authenticated via the 
   AppIdentity service on AppEngine.
  ************************************************/
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 echo pageHeader("AppIdentity Account Access");
 

--- a/examples/batch.php
+++ b/examples/batch.php
@@ -22,7 +22,7 @@ echo pageHeader("Batching Queries");
   books API again as an example, but this time we
   will batch up two queries into a single call.
  ************************************************/
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 /************************************************
   We create the client and set the simple API

--- a/examples/fileupload.php
+++ b/examples/fileupload.php
@@ -17,7 +17,7 @@
 include_once "templates/base.php";
 session_start();
 
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 /************************************************
   We'll setup an empty 20MB file to upload.

--- a/examples/idtoken.php
+++ b/examples/idtoken.php
@@ -17,7 +17,7 @@
 include_once "templates/base.php";
 session_start();
 
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 /************************************************
   ATTENTION: Fill in these values! Make sure

--- a/examples/multi-api.php
+++ b/examples/multi-api.php
@@ -17,7 +17,7 @@
 include_once "templates/base.php";
 session_start();
 
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 /************************************************
   ATTENTION: Fill in these values! Make sure

--- a/examples/service-account.php
+++ b/examples/service-account.php
@@ -21,7 +21,7 @@ include_once "templates/base.php";
   Make an API request authenticated with a service
   account.
  ************************************************/
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 /************************************************
   ATTENTION: Fill in these values! You can get

--- a/examples/simple-query.php
+++ b/examples/simple-query.php
@@ -25,7 +25,7 @@ echo pageHeader("Simple API Access");
   should use our quota, which is higher than the
   anonymous quota (which is limited per IP).
  ************************************************/
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 /************************************************
   We create the client and set the simple API

--- a/examples/simplefileupload.php
+++ b/examples/simplefileupload.php
@@ -17,7 +17,7 @@
 include_once "templates/base.php";
 session_start();
 
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 /************************************************
   We'll setup an empty 1MB file to upload.

--- a/examples/user-example.php
+++ b/examples/user-example.php
@@ -17,7 +17,7 @@
 include_once "templates/base.php";
 session_start();
 
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../src/Google/autoload.php');
 
 /************************************************
   ATTENTION: Fill in these values! Make sure

--- a/src/Google/Auth/Abstract.php
+++ b/src/Google/Auth/Abstract.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Abstract class for the Authentication in the API client

--- a/src/Google/Auth/AppIdentity.php
+++ b/src/Google/Auth/AppIdentity.php
@@ -22,7 +22,7 @@
  */
 use google\appengine\api\app_identity\AppIdentityService;
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Authentication via the Google App Engine App Identity service.

--- a/src/Google/Auth/AssertionCredentials.php
+++ b/src/Google/Auth/AssertionCredentials.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Credentials object used for OAuth 2.0 Signed JWT assertion grants.

--- a/src/Google/Auth/Exception.php
+++ b/src/Google/Auth/Exception.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 class Google_Auth_Exception extends Google_Exception
 {

--- a/src/Google/Auth/LoginTicket.php
+++ b/src/Google/Auth/LoginTicket.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Class to hold information about an authenticated login.

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Authentication class that deals with the OAuth 2 web-server authentication flow

--- a/src/Google/Auth/Simple.php
+++ b/src/Google/Auth/Simple.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Simple API access implementation. Can either be used to make requests

--- a/src/Google/Cache/Apc.php
+++ b/src/Google/Cache/Apc.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * A persistent storage class based on the APC cache, which is not

--- a/src/Google/Cache/Exception.php
+++ b/src/Google/Cache/Exception.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 class Google_Cache_Exception extends Google_Exception
 {

--- a/src/Google/Cache/File.php
+++ b/src/Google/Cache/File.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /*
  * This class implements a basic on disk storage. While that does

--- a/src/Google/Cache/Memcache.php
+++ b/src/Google/Cache/Memcache.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * A persistent storage class based on the memcache, which is not

--- a/src/Google/Cache/Null.php
+++ b/src/Google/Cache/Null.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * A blank storage class, for cases where caching is not

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/autoload.php');
 
 /**
  * The Google API Client

--- a/src/Google/Collection.php
+++ b/src/Google/Collection.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once realpath(dirname(__FILE__) . '/../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/autoload.php');
 
 /**
  * Extension to the regular Google_Model that automatically

--- a/src/Google/Http/Batch.php
+++ b/src/Google/Http/Batch.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * @author Chirag Shah <chirags@google.com>

--- a/src/Google/Http/CacheParser.php
+++ b/src/Google/Http/CacheParser.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Implement the caching directives specified in rfc2616. This

--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * @author Chirag Shah <chirags@google.com>

--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * This class implements the RESTful transport of apiServiceRequest()'s

--- a/src/Google/Http/Request.php
+++ b/src/Google/Http/Request.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * HTTP Request to be executed by IO classes. Upon execution, the

--- a/src/Google/IO/Abstract.php
+++ b/src/Google/IO/Abstract.php
@@ -19,7 +19,7 @@
  * Abstract IO base class
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 abstract class Google_IO_Abstract
 {

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -21,7 +21,7 @@
  * @author Stuart Langley <slangley@google.com>
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 class Google_IO_Curl extends Google_IO_Abstract
 {

--- a/src/Google/IO/Exception.php
+++ b/src/Google/IO/Exception.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 class Google_IO_Exception extends Google_Exception implements Google_Task_Retryable
 {

--- a/src/Google/IO/Stream.php
+++ b/src/Google/IO/Stream.php
@@ -21,7 +21,7 @@
  * @author Stuart Langley <slangley@google.com>
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 class Google_IO_Stream extends Google_IO_Abstract
 {

--- a/src/Google/Logger/Abstract.php
+++ b/src/Google/Logger/Abstract.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Abstract logging class based on the PSR-3 standard.

--- a/src/Google/Logger/Exception.php
+++ b/src/Google/Logger/Exception.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 class Google_Logger_Exception extends Google_Exception
 {

--- a/src/Google/Logger/File.php
+++ b/src/Google/Logger/File.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * File logging class based on the PSR-3 standard.

--- a/src/Google/Logger/Psr.php
+++ b/src/Google/Logger/Psr.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Psr logging class based on the PSR-3 standard.

--- a/src/Google/Service/Exception.php
+++ b/src/Google/Service/Exception.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 class Google_Service_Exception extends Google_Exception implements Google_Task_Retryable
 {

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Implements the actual methods/resources of the discovered Google API using magic function

--- a/src/Google/Signer/P12.php
+++ b/src/Google/Signer/P12.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Signs data.

--- a/src/Google/Task/Exception.php
+++ b/src/Google/Task/Exception.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 class Google_Task_Exception extends Google_Exception
 {

--- a/src/Google/Task/Retryable.php
+++ b/src/Google/Task/Retryable.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Interface for checking how many times a given task can be retried following

--- a/src/Google/Task/Runner.php
+++ b/src/Google/Task/Runner.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * A task runner with exponential backoff support.

--- a/src/Google/Verifier/Pem.php
+++ b/src/Google/Verifier/Pem.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
  
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+require_once realpath(dirname(__FILE__) . '/../autoload.php');
 
 /**
  * Verifies signatures using PEM encoded certificates.

--- a/src/Google/autoload.php
+++ b/src/Google/autoload.php
@@ -15,27 +15,18 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../autoload.php');
-
-/**
- * Null logger based on the PSR-3 standard.
- *
- * This logger simply discards all messages.
- */
-class Google_Logger_Null extends Google_Logger_Abstract
-{
-  /**
-   * {@inheritdoc}
-   */
-  public function shouldHandle($level)
-  {
-    return false;
+function google_api_php_client_autoload($className) {
+  $classPath = explode('_', $className);
+  if ($classPath[0] != 'Google') {
+    return;
   }
+  // Drop 'Google', and maximum class file path depth in this project is 3.
+  $classPath = array_slice($classPath, 1, 2);
 
-  /**
-   * {@inheritdoc}
-   */
-  protected function write($message, array $context = array())
-  {
+  $filePath = dirname(__FILE__) . '/' . implode('/', $classPath) . '.php';
+  if (file_exists($filePath)) {
+    require_once($filePath);
   }
 }
+
+spl_autoload_register('google_api_php_client_autoload');

--- a/tests/OAuthHelper.php
+++ b/tests/OAuthHelper.php
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once dirname(__FILE__) . '/../autoload.php';
+require_once dirname(__FILE__) . '/../src/Google/autoload.php';
 
 $client = new Google_Client();
 $client->setScopes(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once dirname(__FILE__) . '/../autoload.php';
+require_once dirname(__FILE__) . '/../src/Google/autoload.php';
 require_once dirname(__FILE__) . '/BaseTest.php';
 
 date_default_timezone_set('UTC');


### PR DESCRIPTION
This makes system-wide installation of the library more viable.

It's a quick job, but it looks fine. I ran the test suite and got the same results before and after.