### PR TITLE
Allow cURL options to be set through setClassConfig

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -80,7 +80,12 @@ class Google_IO_Curl extends Google_IO_Abstract
     if ($request->canGzip()) {
       curl_setopt($curl, CURLOPT_ENCODING, 'gzip,deflate');
     }
-
+    
+    $options = $this->client->getClassConfig('Google_IO_Curl', 'options');
+        if (is_array($options)){
+        $this->setOptions($options);
+    }
+    
     foreach ($this->options as $key => $var) {
       curl_setopt($curl, $key, $var);
     }

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -82,8 +82,8 @@ class Google_IO_Curl extends Google_IO_Abstract
     }
     
     $options = $this->client->getClassConfig('Google_IO_Curl', 'options');
-        if (is_array($options)) {
-        $this->setOptions($options);
+    if (is_array($options)) {
+      $this->setOptions($options);
     }
     
     foreach ($this->options as $key => $var) {

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -82,7 +82,7 @@ class Google_IO_Curl extends Google_IO_Abstract
     }
     
     $options = $this->client->getClassConfig('Google_IO_Curl', 'options');
-        if (is_array($options)){
+        if (is_array($options)) {
         $this->setOptions($options);
     }
     


### PR DESCRIPTION
Will allow developers to set additional cURL options when needed.

For example, googleapis.com resolves to both IPv4 and IPv6 addresses now. Some hosting providers don't have IPv6 support and a cURL request will fail when trying to connect to an IPv6 address.

Being able to set cURL options, developers can handle this issue using CURLOPT_IPRESOLVE to force IPv4, IPv6 or Both.