### PR TITLE
flock() not getting file handle all the time

### DIFF
--- a/src/Google/Cache/File.php
+++ b/src/Google/Cache/File.php
@@ -170,6 +170,13 @@ class Google_Cache_File extends Google_Cache_Abstract
   {
     $mode = $type == LOCK_EX ? "w" : "r";
     $this->fh = fopen($storageFile, $mode);
+    if (!$this->fh) {
+      $this->client->getLogger()->error(
+        'Failed to open file during lock acquisition',
+        array('file' => $storageFile)
+      );
+      return false;
+    }
     $count = 0;
     while (!flock($this->fh, $type | LOCK_NB)) {
       // Sleep for 10ms.


### PR DESCRIPTION
Removed the assumption of successful file handle acquisition while trying obtain a lock on a cache file. This has caused the following errors to pop up in my logs:

`flock() expects parameter 1 to be resource, boolean given`

In other words we shouldn't try and get a lock on a file we can't open. I suppose the eventual solution would be to find why the file can't be opened in the first place, but, this only happens occasionally so it might be some kind of race condition or something.