### PR TITLE
Fix for file download from cloud storage

### DIFF
--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -113,6 +113,10 @@ class Google_Http_REST
 
     // Only attempt to decode the response, if the response code wasn't (204) 'no content'
     if ($code != '204') {
+      if ($response->getExpectedRaw()) {
+        return $body;
+      }
+      
       $decoded = json_decode($body, true);
       if ($decoded === null || $decoded === "") {
         $error = "Invalid json in service response: $body";

--- a/src/Google/Http/Request.php
+++ b/src/Google/Http/Request.php
@@ -49,6 +49,7 @@ class Google_Http_Request
   protected $responseBody;
   
   protected $expectedClass;
+  protected $expectedRaw = false;
 
   public $accessKey;
 
@@ -186,6 +187,31 @@ class Google_Http_Request
   public function getExpectedClass()
   {
     return $this->expectedClass;
+  }
+
+  /**
+   * Enable expected raw response
+   */
+  public function enableExpectedRaw()
+  {
+    $this->expectedRaw = true;
+  }
+
+  /**
+   * Disable expected raw response
+   */
+  public function disableExpectedRaw()
+  {
+    $this->expectedRaw = false;
+  }
+
+  /**
+   * Expected raw response or not.
+   * @return boolean expected raw response
+   */
+  public function getExpectedRaw()
+  {
+    return $this->expectedRaw;
   }
 
   /**

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -219,6 +219,10 @@ class Google_Service_Resource
       );
     }
 
+    if (isset($parameters['alt']) && $parameters['alt']['value'] == 'media') {
+      $httpRequest->enableExpectedRaw();
+    }
+
     if ($this->client->shouldDefer()) {
       // If we are in batch or upload mode, return the raw request.
       return $httpRequest;


### PR DESCRIPTION
Currently when running a get request on storage with `alt=media` the library will try and decode the response into json, however when `alt=media` is specified to download the file the api returns the file contents as the body. In this case the library should simply return the raw body without trying to decode. #480 