### PR TITLE
no notice for count on empty collections

### DIFF
--- a/src/Google/Collection.php
+++ b/src/Google/Collection.php
@@ -48,6 +48,9 @@ class Google_Collection extends Google_Model implements Iterator, Countable
 
   public function count()
   {
+    if(!isset($this->modelData[$this->collection_key])) {
+      return 0;
+    }
     return count($this->modelData[$this->collection_key]);
   }
 


### PR DESCRIPTION
I tried to check for Shopping Content accounts if there are products uploaded for specific accounts:
```php
$service = new Google_Service_ShoppingContent($Client);
$productList = $service->products->listProducts($account['id']);
print_r($productList->count());
```

If the account does not have any products yet, I'd expect the count to be 0, however a warning gets triggered:
> PHP Notice:  Undefined index: resources in .../vendor/google/apiclient/src/Google/Collection.php on line 51