### PR TITLE
Change servicePath for file upload with parent

### DIFF
--- a/src/Google/Service/Drive.php
+++ b/src/Google/Service/Drive.php
@@ -1500,7 +1500,11 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
   {
     $params = array('folderId' => $folderId, 'postBody' => $postBody);
     $params = array_merge($params, $optParams);
-    return $this->call('insert', array($params), "Google_Service_Drive_ChildReference");
+    $primaryPath = $this->servicePath;
+    $this->servicePath = 'upload/' . $this->servicePath;
+    $result = $this->call('insert', array($params), "Google_Service_Drive_ChildReference");
+    $this->servicePath = $primaryPath;
+    return $result;
   }
 
   /**


### PR DESCRIPTION
The Google API returns a 400 error when files are uploaded to the default service path, but only when a parent folder is specified. The error message says: _Uploads must be sent to the upload URL_. This error can be resolved by prepending ```upload/``` to the service path URL. 