### PR TITLE
Unused private variables in Authentification classes

### DIFF
--- a/src/Google/Auth/AppIdentity.php
+++ b/src/Google/Auth/AppIdentity.php
@@ -32,7 +32,6 @@ if (!class_exists('Google_Client')) {
 class Google_Auth_AppIdentity extends Google_Auth_Abstract
 {
   const CACHE_PREFIX = "Google_Auth_AppIdentity::";
-  private $key = null;
   private $client;
   private $token = false;
   private $tokenScopes = false;

--- a/src/Google/Auth/Simple.php
+++ b/src/Google/Auth/Simple.php
@@ -26,7 +26,6 @@ if (!class_exists('Google_Client')) {
  */
 class Google_Auth_Simple extends Google_Auth_Abstract
 {
-  private $key = null;
   private $client;
 
   public function __construct(Google_Client $client, $config = null)


### PR DESCRIPTION
Fixes https://github.com/google/google-api-php-client/issues/527