### PR TITLE
Removed service to avoid recursion problem

### DIFF
--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -42,14 +42,14 @@ class Google_Service_Resource
       'prettyPrint' => array('type' => 'string', 'location' => 'query'),
   );
 
-  /** @var Google_Service $service */
-  private $service;
-
   /** @var Google_Client $client */
   private $client;
 
   /** @var string $serviceName */
   private $serviceName;
+
+  /** @var string $servicePath */
+  private $servicePath;
 
   /** @var string $resourceName */
   private $resourceName;
@@ -59,8 +59,8 @@ class Google_Service_Resource
 
   public function __construct($service, $serviceName, $resourceName, $resource)
   {
-    $this->service = $service;
     $this->client = $service->getClient();
+    $this->servicePath = $service->servicePath;
     $this->serviceName = $serviceName;
     $this->resourceName = $resourceName;
     $this->methods = isset($resource['methods']) ?
@@ -173,8 +173,6 @@ class Google_Service_Resource
       }
     }
 
-    $servicePath = $this->service->servicePath;
-
     $this->client->getLogger()->info(
         'Service Call',
         array(
@@ -186,7 +184,7 @@ class Google_Service_Resource
     );
 
     $url = Google_Http_REST::createRequestUri(
-        $servicePath,
+        $this->servicePath,
         $method['path'],
         $parameters
     );


### PR DESCRIPTION
In order to avoid problems with recursion, I would suggest to store in the resource object only the information necessary from the service, in this case path.

Fixes https://github.com/google/google-api-php-client/issues/533