### PR TITLE
Avoid double URL encoding for params' values

### DIFF
--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -153,10 +153,10 @@ class Google_Http_REST
       } else if ($paramSpec['location'] == 'query') {
         if (isset($paramSpec['repeated']) && is_array($paramSpec['value'])) {
           foreach ($paramSpec['value'] as $value) {
-            $queryVars[] = $paramName . '=' . rawurlencode($value);
+            $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($value));
           }
         } else {
-          $queryVars[] = $paramName . '=' . rawurlencode($paramSpec['value']);
+          $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($paramSpec['value']));
         }
       }
     }


### PR DESCRIPTION
According to documentation, for filters, URL-reserved characters — Characters such as & must be url-encoded in the usual way, see https://developers.google.com/analytics/devguides/reporting/core/v3/reference#filterExpressions

If in a filter such as ga:pagePath an URI is used, which needs to be url-encoded, the createRequestUri method will apply an additional rawurlencode() on it resulting in a double URL encoding.