### PR TITLE
Allow for valid cross client authentication requests

### DIFF
--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -82,7 +82,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
    * @throws Google_Auth_Exception
    * @return string
    */
-  public function authenticate($code, $crossClient)
+  public function authenticate($code, $crossClient = false)
   {
     if (strlen($code) == 0) {
       throw new Google_Auth_Exception("Invalid code");

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -78,13 +78,25 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
 
   /**
    * @param string $code
+   * @param boolean $crossClient
    * @throws Google_Auth_Exception
    * @return string
    */
-  public function authenticate($code)
+  public function authenticate($code, $crossClient)
   {
     if (strlen($code) == 0) {
       throw new Google_Auth_Exception("Invalid code");
+    }
+
+    $arguments = array(
+          'code' => $code,
+          'grant_type' => 'authorization_code',
+          'client_id' => $this->client->getClassConfig($this, 'client_id'),
+          'client_secret' => $this->client->getClassConfig($this, 'client_secret')
+    );
+
+    if($crossClient !== true) {
+        $arguments['redirect_uri'] = $this->client->getClassConfig($this, 'redirect_uri');
     }
 
     // We got here from the redirect from a successful authorization grant,
@@ -93,13 +105,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
         self::OAUTH2_TOKEN_URI,
         'POST',
         array(),
-        array(
-          'code' => $code,
-          'grant_type' => 'authorization_code',
-          'redirect_uri' => $this->client->getClassConfig($this, 'redirect_uri'),
-          'client_id' => $this->client->getClassConfig($this, 'client_id'),
-          'client_secret' => $this->client->getClassConfig($this, 'client_secret')
-        )
+        $arguments
     );
     $request->disableGzip();
     $response = $this->client->getIo()->makeRequest($request);

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -114,15 +114,18 @@ class Google_Client
 
   /**
    * Attempt to exchange a code for an valid authentication token.
+   * If $crossClient is set to true, the request body will not include
+   * the request_uri argument
    * Helper wrapped around the OAuth 2.0 implementation.
    *
    * @param $code string code from accounts.google.com
+   * @param $crossIdentity boolean, whether this is a cross-client authentication
    * @return string token
    */
-  public function authenticate($code)
+  public function authenticate($code, $crossClient = false)
   {
     $this->authenticated = true;
-    return $this->getAuth()->authenticate($code);
+    return $this->getAuth()->authenticate($code, $crossClient);
   }
   
   /**

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -119,7 +119,7 @@ class Google_Client
    * Helper wrapped around the OAuth 2.0 implementation.
    *
    * @param $code string code from accounts.google.com
-   * @param $crossIdentity boolean, whether this is a cross-client authentication
+   * @param $crossClient boolean, whether this is a cross-client authentication
    * @return string token
    */
   public function authenticate($code, $crossClient = false)


### PR DESCRIPTION
Here's a pull request to allow for valid authenticate requests, using an authorization code obtained through the cross client authorization scheme, as described here https://developers.google.com/identity/protocols/CrossClientAuth

  As the documentation sais, the request body should not include the request_uri argument.