### PR TITLE
Add separate createBatch method to propagate batch URLs properly

### DIFF
--- a/src/Google/Http/Batch.php
+++ b/src/Google/Http/Batch.php
@@ -35,12 +35,15 @@ class Google_Http_Batch
 
   private $expected_classes = array();
 
-  private $base_path;
+  private $root_url;
 
-  public function __construct(Google_Client $client, $boundary = false)
+  private $batch_path;
+
+  public function __construct(Google_Client $client, $boundary = false, $rootUrl = '', $batchPath = '')
   {
     $this->client = $client;
-    $this->base_path = $this->client->getBasePath();
+    $this->root_url = rtrim($rootUrl ? $rootUrl : $this->client->getBasePath(), '/');
+    $this->batch_path = $batchPath ? $batchPath : 'batch';
     $this->expected_classes = array();
     $boundary = (false == $boundary) ? mt_rand() : $boundary;
     $this->boundary = str_replace('"', '', $boundary);
@@ -62,14 +65,13 @@ class Google_Http_Batch
     /** @var Google_Http_Request $req */
     foreach ($this->requests as $key => $req) {
       $body .= "--{$this->boundary}\n";
-      $body .= $req->toBatchString($key) . "\n";
+      $body .= $req->toBatchString($key) . "\n\n";
       $this->expected_classes["response-" . $key] = $req->getExpectedClass();
     }
 
-    $body = rtrim($body);
-    $body .= "\n--{$this->boundary}--";
+    $body .= "--{$this->boundary}--";
 
-    $url = $this->base_path . '/batch';
+    $url = $this->root_url . '/' . $this->batch_path;
     $httpRequest = new Google_Http_Request($url, 'POST');
     $httpRequest->setRequestHeaders(
         array('Content-Type' => 'multipart/mixed; boundary=' . $this->boundary)

--- a/src/Google/Service.php
+++ b/src/Google/Service.php
@@ -17,6 +17,7 @@
 
 class Google_Service
 {
+  public $batchPath;
   public $rootUrl;
   public $version;
   public $servicePath;
@@ -37,4 +38,20 @@ class Google_Service
   {
     return $this->client;
   }
+
+  /**
+   * Create a new HTTP Batch handler for this service
+   *
+   * @return Google_Http_Batch
+   */
+  public function createBatch()
+  {
+    return new Google_Http_Batch(
+      $this->client,
+      false,
+      $this->rootUrl,
+      $this->batchPath
+    );
+  }
+
 }

--- a/tests/general/Http/BatchTest.php
+++ b/tests/general/Http/BatchTest.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ * Copyright 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class BatchTest extends PHPUnit_Framework_TestCase
+{
+
+  public function setUp()
+  {
+    $this->client = $this->getMockBuilder("Google_Client")
+                         ->disableOriginalConstructor()
+                         ->getMock();
+  }
+  
+  public function testBasicFunctionality()
+  {
+    $this->client->expects($this->once())
+            ->method("getBasePath")
+            ->will($this->returnValue("base_path"));
+    $batch = new Google_Http_Batch($this->client);
+    $this->assertAttributeEquals("base_path", "root_url", $batch);
+    $this->assertAttributeEquals("batch", "batch_path", $batch);
+  }
+
+  public function testExtractionOfRootUrlFromService()
+  {
+    $this->client->expects($this->never())
+            ->method("getBasePath");
+    $service = new Google_Service($this->client);
+    $service->rootUrl = "root_url_dummy";
+    $service->batchPath = "batch_path_dummy";
+    $batch = $service->createBatch();
+    $this->assertInstanceOf("Google_Http_Batch", $batch);
+    $this->assertAttributeEquals("root_url_dummy", "root_url", $batch);
+    $this->assertAttributeEquals("batch_path_dummy", "batch_path", $batch);
+  }
+
+  public function testExecuteCustomRootUrlBatchPath()
+  {
+    $io = $this->getMockBuilder('Google_IO_Abstract')
+            ->disableOriginalConstructor()
+            ->setMethods(['makeRequest', 'needsQuirk', 'executeRequest', 'setOptions', 'setTimeout', 'getTimeout'])
+            ->getMock();
+    $req = null;
+    $io->expects($this->once())
+            ->method("makeRequest")
+            ->will($this->returnCallback(function($request) use (&$req) {
+                $req = $request;
+                return $request;
+            }));
+    $this->client->expects($this->once())
+            ->method("getIo")
+            ->will($this->returnValue($io));
+    $batch = new Google_Http_Batch($this->client, false, 'https://www.example.com/', 'bat');
+    $this->assertNull($batch->execute());
+    $this->assertInstanceOf("Google_Http_Request", $req);
+    $this->assertEquals("https://www.example.com/bat", $req->getUrl());
+  }
+
+  public function testExecuteBodySerialization()
+  {
+    $io = $this->getMockBuilder('Google_IO_Abstract')
+            ->disableOriginalConstructor()
+            ->setMethods(['makeRequest', 'needsQuirk', 'executeRequest', 'setOptions', 'setTimeout', 'getTimeout'])
+            ->getMock();
+    $req = null;
+    $io->expects($this->once())
+            ->method("makeRequest")
+            ->will($this->returnCallback(function($request) use (&$req) {
+                $req = $request;
+                return $request;
+            }));
+    $this->client->expects($this->once())
+            ->method("getIo")
+            ->will($this->returnValue($io));
+    $batch = new Google_Http_Batch($this->client, "BOUNDARY_TEXT", 'https://www.example.com/', 'bat');
+    $req1 = new Google_Http_Request("https://www.example.com/req1");
+    $req2 = new Google_Http_Request("https://www.example.com/req2", 'POST', array(), 'POSTBODY');
+    $batch->add($req1, '1');
+    $batch->add($req2, '2');
+    $this->assertNull($batch->execute());
+    $this->assertInstanceOf("Google_Http_Request", $req);
+    $format = <<<'EOF'
+--BOUNDARY_TEXT
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+MIME-Version: 1.0
+Content-ID: 1
+
+GET /req1? HTTP/1.1
+
+
+--BOUNDARY_TEXT
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+MIME-Version: 1.0
+Content-ID: 2
+
+POST /req2? HTTP/1.1
+
+POSTBODY
+
+--BOUNDARY_TEXT--
+EOF;
+    $this->assertEquals($format, $req->getPostBody());
+  }
+
+}

--- a/tests/general/Http/BatchTest.php
+++ b/tests/general/Http/BatchTest.php
@@ -52,7 +52,7 @@ class BatchTest extends PHPUnit_Framework_TestCase
   {
     $io = $this->getMockBuilder('Google_IO_Abstract')
             ->disableOriginalConstructor()
-            ->setMethods(['makeRequest', 'needsQuirk', 'executeRequest', 'setOptions', 'setTimeout', 'getTimeout'])
+            ->setMethods(array('makeRequest', 'needsQuirk', 'executeRequest', 'setOptions', 'setTimeout', 'getTimeout'))
             ->getMock();
     $req = null;
     $io->expects($this->once())
@@ -74,7 +74,7 @@ class BatchTest extends PHPUnit_Framework_TestCase
   {
     $io = $this->getMockBuilder('Google_IO_Abstract')
             ->disableOriginalConstructor()
-            ->setMethods(['makeRequest', 'needsQuirk', 'executeRequest', 'setOptions', 'setTimeout', 'getTimeout'])
+            ->setMethods(array('makeRequest', 'needsQuirk', 'executeRequest', 'setOptions', 'setTimeout', 'getTimeout'))
             ->getMock();
     $req = null;
     $io->expects($this->once())

--- a/tests/general/ServiceTest.php
+++ b/tests/general/ServiceTest.php
@@ -33,6 +33,7 @@ class TestModel extends Google_Model
 
 class ServiceTest extends PHPUnit_Framework_TestCase
 {
+
   public function testModel()
   {
     $model = new TestModel();


### PR DESCRIPTION
Presently, batch URLs use the system configured global URL and a hard-coded batch path. This PR allows for services to specify the batch end point. 

It also fixes a problem with batches not correctly terminating headers when there is no body to the request.