### PR TITLE
Fix: Install dependencies in install section on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
   global:
-    - MEMCACHE_HOST=127.0.0.1 
+    - MEMCACHE_HOST=127.0.0.1
     - MEMCACHE_PORT=11211
 
 sudo: false
@@ -19,8 +19,10 @@ php:
   - 5.6
   - hhvm
 
-before_script:
+install:
   - composer install
+
+before_script:
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension=memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
   - phpenv version-name | grep ^5.[34] && echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; true


### PR DESCRIPTION
This PR

* [x] moves installation of dependencies with Composer to the `install` section of the Travis configuration