### PR TITLE
Enhancement: Cache dependencies between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,14 @@ services:
 
 env:
   global:
-    - MEMCACHE_HOST=127.0.0.1 
+    - MEMCACHE_HOST=127.0.0.1
     - MEMCACHE_PORT=11211
 
 sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 php:
   # Can't test against 5.2; openssl is not available:


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with Composer between Travis builds

:information_desk_person: This should speed up builds.