### PR TITLE
Fix: Update Composer itself in before_install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ php:
   - 5.6
   - hhvm
 
+before_install:
+  - composer self-update
+
 install:
   - composer install
 


### PR DESCRIPTION
This PR

* [x] updates Composer itself in the `before_install` section on Travis