### PR TITLE
Enhancement: Run phpcs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,16 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-php:
-  # Can't test against 5.2; openssl is not available:
-  # http://docs.travis-ci.com/user/languages/php/#PHP-installation
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
+matrix:
+  include:
+    # Can't test against 5.2; openssl is not available:
+    # http://docs.travis-ci.com/user/languages/php/#PHP-installation
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env: PHPCS=true
+    - php: hhvm
 
 install:
   - composer install
@@ -34,4 +36,4 @@ before_script:
 
 script:
   - vendor/bin/phpunit
-  - vendor/bin/phpcs src --standard=style/ruleset.xml -np
+  - if [[ "$PHPCS" == "true" ]]; then vendor/bin/phpcs src --standard=style/ruleset.xml -np; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
     - $HOME/.composer/cache
 
 matrix:
+  fast_finish: true
   include:
     # Can't test against 5.2; openssl is not available:
     # http://docs.travis-ci.com/user/languages/php/#PHP-installation

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,4 @@ before_script:
 
 script:
   - vendor/bin/phpunit
+  - vendor/bin/phpcs src --standard=style/ruleset.xml -np

--- a/README.md
+++ b/README.md
@@ -84,18 +84,22 @@ $opt_params = array(
 
 The library strips out nulls from the objects sent to the Google APIs as its the default value of all of the uninitialised properties. To work around this, set the field you want to null to Google_Model::NULL_VALUE. This is a placeholder that will be replaced with a true null when sent over the wire.
 
-## Notes For Distributors ##
-
-To avoid clashes with the autoloader, its best to update the function inside autoload.php to `google_api_php_client_autoload_MyProject`.
-
 ## Code Quality ##
 
 Run the PHPUnit tests with PHPUnit. You can configure an API key and token in BaseTest.php to run all calls, but this will require some setup on the Google Developer Console.
 
     phpunit tests/
 
-Copy the ruleset.xml in style/ into a new directory named GAPI/ in your
-/usr/share/php/PHP/CodeSniffer/Standards (or appropriate equivalent directory),
-and run code sniffs with:
+### Coding Style
 
-        phpcs --standard=GAPI src/
+To check for coding style violations, run
+
+```
+vendor/bin/phpcs src --standard=style/ruleset.xml -np 
+```
+
+To automatically fix (fixable) coding style violations, run  
+
+```
+vendor/bin/phpcbf src --standard=style/ruleset.xml
+```

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "php": ">=5.2.1"
     },
     "require-dev": {
-      "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.7.*",
+        "squizlabs/php_codesniffer": "~2.3"
     },
     "autoload": {
         "classmap": [

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -95,7 +95,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
           'client_secret' => $this->client->getClassConfig($this, 'client_secret')
     );
 
-    if($crossClient !== true) {
+    if ($crossClient !== true) {
         $arguments['redirect_uri'] = $this->client->getClassConfig($this, 'redirect_uri');
     }
 

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -129,10 +129,10 @@ class Google_Client
   }
   
   /**
-   * Loads a service account key and parameters from a JSON 
+   * Loads a service account key and parameters from a JSON
    * file from the Google Developer Console. Uses that and the
-   * given array of scopes to return an assertion credential for 
-   * use with refreshTokenWithAssertionCredential. 
+   * given array of scopes to return an assertion credential for
+   * use with refreshTokenWithAssertionCredential.
    *
    * @param string $jsonLocation File location of the project-key.json.
    * @param array $scopes The scopes to assert.

--- a/src/Google/Collection.php
+++ b/src/Google/Collection.php
@@ -56,7 +56,7 @@ class Google_Collection extends Google_Model implements Iterator, Countable
     return count($this->modelData[$this->collection_key]);
   }
 
-  public function offsetExists ($offset)
+  public function offsetExists($offset)
   {
     if (!is_numeric($offset)) {
       return parent::offsetExists($offset);

--- a/src/Google/Config.php
+++ b/src/Google/Config.php
@@ -380,8 +380,8 @@ class Google_Config
   /**
    * Set the hd (hosted domain) parameter streamlines the login process for
    * Google Apps hosted accounts. By including the domain of the user, you
-   * restrict sign-in to accounts at that domain. 
-   * 
+   * restrict sign-in to accounts at that domain.
+   *
    * This should not be used to ensure security on your application - check
    * the hd values within an id token (@see Google_Auth_LoginTicket) after sign
    * in to ensure that the user is from the domain you were expecting.

--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -287,7 +287,7 @@ class Google_Http_MediaFileUpload
     }
     $message = $code;
     $body = @json_decode($response->getResponseBody());
-    if (!empty( $body->error->errors ) ) {
+    if (!empty($body->error->errors) ) {
       $message .= ': ';
       foreach ($body->error->errors as $error) {
         $message .= "{$error->domain}, {$error->message};";

--- a/src/Google/Http/Request.php
+++ b/src/Google/Http/Request.php
@@ -130,7 +130,7 @@ class Google_Http_Request
     return $this->queryParams;
   }
 
-  /** 
+  /**
    * Set a new query parameter.
    * @param $key - string to set, does not need to be URL encoded
    * @param $value - string to set, does not need to be URL encoded
@@ -441,7 +441,7 @@ class Google_Http_Request
   
   /**
    * Our own version of parse_str that allows for multiple variables
-   * with the same name. 
+   * with the same name.
    * @param $string - the query string to parse
    */
   private function parseQuery($string)
@@ -465,7 +465,7 @@ class Google_Http_Request
   
   /**
    * A version of build query that allows for multiple
-   * duplicate keys. 
+   * duplicate keys.
    * @param $parts array of key value pairs
    */
   private function buildQuery($parts)
@@ -483,7 +483,7 @@ class Google_Http_Request
     return implode('&', $return);
   }
   
-  /** 
+  /**
    * If we're POSTing and have no body to send, we can send the query
    * parameters in there, which avoids length issues with longer query
    * params.

--- a/src/Google/Model.php
+++ b/src/Google/Model.php
@@ -25,7 +25,7 @@ class Google_Model implements ArrayAccess
 {
   /**
    * If you need to specify a NULL JSON value, use Google_Model::NULL_VALUE
-   * instead - it will be replaced when converting to JSON with a real null. 
+   * instead - it will be replaced when converting to JSON with a real null.
    */
   const NULL_VALUE = "{}gapi-php-null";
   protected $internal_gapi_mappings = array();

--- a/src/Google/Service.php
+++ b/src/Google/Service.php
@@ -47,11 +47,10 @@ class Google_Service
   public function createBatch()
   {
     return new Google_Http_Batch(
-      $this->client,
-      false,
-      $this->rootUrl,
-      $this->batchPath
+        $this->client,
+        false,
+        $this->rootUrl,
+        $this->batchPath
     );
   }
-
 }

--- a/src/Google/Service/Cloudsearch.php
+++ b/src/Google/Service/Cloudsearch.php
@@ -51,7 +51,3 @@ class Google_Service_Cloudsearch extends Google_Service
 
   }
 }
-
-
-
-

--- a/src/Google/Service/Genomics.php
+++ b/src/Google/Service/Genomics.php
@@ -51,7 +51,3 @@ class Google_Service_Genomics extends Google_Service
 
   }
 }
-
-
-
-

--- a/src/Google/Service/Playmoviespartner.php
+++ b/src/Google/Service/Playmoviespartner.php
@@ -51,7 +51,3 @@ class Google_Service_Playmoviespartner extends Google_Service
 
   }
 }
-
-
-
-

--- a/src/Google/Signer/P12.php
+++ b/src/Google/Signer/P12.php
@@ -46,7 +46,7 @@ class Google_Signer_P12 extends Google_Signer_Abstract
     // at the time.
     if (!$password && strpos($p12, "-----BEGIN RSA PRIVATE KEY-----") !== false) {
       $this->privateKey = openssl_pkey_get_private($p12);
-    } elseif($password === 'notasecret' && strpos($p12, "-----BEGIN PRIVATE KEY-----") !== false) {
+    } elseif ($password === 'notasecret' && strpos($p12, "-----BEGIN PRIVATE KEY-----") !== false) {
       $this->privateKey = openssl_pkey_get_private($p12);
     } else {
       // This throws on error

--- a/src/Google/Utils/URITemplate.php
+++ b/src/Google/Utils/URITemplate.php
@@ -16,7 +16,7 @@
  */
 
 /**
- * Implementation of levels 1-3 of the URI Template spec. 
+ * Implementation of levels 1-3 of the URI Template spec.
  * @see http://tools.ietf.org/html/rfc6570
  */
 class Google_Utils_URITemplate
@@ -26,7 +26,7 @@ class Google_Utils_URITemplate
   const TYPE_SCALAR = "4";
 
   /**
-   * @var $operators array 
+   * @var $operators array
    * These are valid at the start of a template block to
    * modify the way in which the variables inside are
    * processed.
@@ -64,7 +64,7 @@ class Google_Utils_URITemplate
   /**
    * This function finds the first matching {...} block and
    * executes the replacement. It then calls itself to find
-   * subsequent blocks, if any. 
+   * subsequent blocks, if any.
    */
   private function resolveNextSection($string, $parameters)
   {
@@ -213,7 +213,7 @@ class Google_Utils_URITemplate
     
     if (isset($parameters[$key])) {
       $data_type = $this->getDataType($parameters[$key]);
-      switch($data_type) {
+      switch ($data_type) {
         case self::TYPE_SCALAR:
           $value = $this->getValue($parameters[$key], $length);
           break;

--- a/src/Google/autoload.php
+++ b/src/Google/autoload.php
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-spl_autoload_register(function ($className) {
-  $classPath = explode('_', $className);
-  if ($classPath[0] != 'Google') {
-    return;
-  }
-  // Drop 'Google', and maximum class file path depth in this project is 3.
-  $classPath = array_slice($classPath, 1, 2);
+spl_autoload_register(
+    function ($className) {
+      $classPath = explode('_', $className);
+      if ($classPath[0] != 'Google') {
+        return;
+      }
+      // Drop 'Google', and maximum class file path depth in this project is 3.
+      $classPath = array_slice($classPath, 1, 2);
 
-  $filePath = dirname(__FILE__) . '/' . implode('/', $classPath) . '.php';
-  if (file_exists($filePath)) {
-    require_once($filePath);
-  }
-});
+      $filePath = dirname(__FILE__) . '/' . implode('/', $classPath) . '.php';
+      if (file_exists($filePath)) {
+        require_once($filePath);
+      }
+    }
+);

--- a/src/Google/autoload.php
+++ b/src/Google/autoload.php
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-function google_api_php_client_autoload($className)
-{
+spl_autoload_register(function ($className) {
   $classPath = explode('_', $className);
   if ($classPath[0] != 'Google') {
     return;
@@ -28,6 +27,4 @@ function google_api_php_client_autoload($className)
   if (file_exists($filePath)) {
     require_once($filePath);
   }
-}
-
-spl_autoload_register('google_api_php_client_autoload');
+});


### PR DESCRIPTION
This PR

* [x] requires `squizlabs/php_codesniffer` as a development dependency
* [x] runs `phpcs` on Travis to determine coding style violations
* [x] runs `phpcs` only against PHP 5.6 Travis to save build time and resources
* [x] fixes the build by running `phpcbf`
* [x] inlines the autoload function `google_api_php_client_autoload` to fix the issue with non-camel-caps method naming
* [x] updates `README.md` with notes about how to check for coding style issues, and how to fix them

Related to #586.