### PR TITLE
Fix an issue with custom headers, OAuth and Curl

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -66,8 +66,10 @@ class Google_IO_Curl extends Google_IO_Abstract
       }
 
       if (isset($this->options[CURLOPT_HTTPHEADER])) {
-        foreach($this->options[CURLOPT_HTTPHEADER] as $optionHeader) {
-          $curlHeaders[] = $optionHeader;
+        if (is_array($this->options[CURLOPT_HTTPHEADER])) {
+          foreach($this->options[CURLOPT_HTTPHEADER] as $optionHeader) {
+            $curlHeaders[] = $optionHeader;
+          }
         }
         unset($this->options[CURLOPT_HTTPHEADER]);
       }

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -67,7 +67,7 @@ class Google_IO_Curl extends Google_IO_Abstract
 
       if (isset($this->options[CURLOPT_HTTPHEADER])) {
         if (is_array($this->options[CURLOPT_HTTPHEADER])) {
-          foreach($this->options[CURLOPT_HTTPHEADER] as $optionHeader) {
+          foreach ($this->options[CURLOPT_HTTPHEADER] as $optionHeader) {
             $curlHeaders[] = $optionHeader;
           }
         }

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -64,6 +64,14 @@ class Google_IO_Curl extends Google_IO_Abstract
       foreach ($requestHeaders as $k => $v) {
         $curlHeaders[] = "$k: $v";
       }
+
+      if (isset($this->options[CURLOPT_HTTPHEADER])) {
+        foreach($this->options[CURLOPT_HTTPHEADER] as $optionHeader) {
+          $curlHeaders[] = $optionHeader;
+        }
+        unset($this->options[CURLOPT_HTTPHEADER]);
+      }
+
       curl_setopt($curl, CURLOPT_HTTPHEADER, $curlHeaders);
     }
     curl_setopt($curl, CURLOPT_URL, $request->getUrl());


### PR DESCRIPTION
In Curl.php the headers are set first :

    curl_setopt($curl, CURLOPT_HTTPHEADER, $curlHeaders);

And then custom options set later:

    foreach ($this->options as $key => $var) {
      curl_setopt($curl, $key, $var);
    }

Unfortunately if `$this->options` contains any anything with $key = 10023 - even an empty array - it will override the headers set previously - e.g. `Authorization: bearer`. 

This little fix removes the headers from the options after setting them at the same time as the standard request headers. 