### PR TITLE
Batch HTTP Client, previous requests not cleared

### DIFF
--- a/src/Google/Http/Batch.php
+++ b/src/Google/Http/Batch.php
@@ -79,7 +79,9 @@ class Google_Http_Batch
 
     $httpRequest->setPostBody($body);
     $response = $this->client->getIo()->makeRequest($httpRequest);
-
+    
+    $this->requests = array();
+    
     return $this->parseResponse($response);
   }
 


### PR DESCRIPTION
$this->requests never gets cleared after exec().  Therefore multiple calls to the same instance of the class yield repeated results for the same requests !