### PR TITLE
easier access token testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 vendor
 examples/testfile-small.txt
 examples/testfile.txt
+tests/.accessToken

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -25,10 +25,8 @@ class BaseTest extends PHPUnit_Framework_TestCase
   public function __construct()
   {
     parent::__construct();
-    // Fill in a token JSON here and you can test the oauth token
-    // requiring functions.
-    // $this->token = '';
 
+    $this->token = $this->loadToken();
     $this->memcacheHost = getenv('MEMCACHE_HOST') ? getenv('MEMCACHE_HOST') : null;
     $this->memcachePort = getenv('MEMCACHE_PORT') ? getenv('MEMCACHE_PORT') : null;
   }
@@ -50,9 +48,21 @@ class BaseTest extends PHPUnit_Framework_TestCase
   public function checkToken()
   {
     if (!strlen($this->token)) {
-      $this->markTestSkipped('Test requires access token');
+      $this->markTestSkipped("Test requires access token\nrun \"php tests/OAuthHelper.php\"");
       return false;
     }
     return true;
+  }
+
+  public function loadToken()
+  {
+    if (file_exists($f = dirname(__FILE__) . DIRECTORY_SEPARATOR . '.accessToken')) {
+      $t = file_get_contents($f);
+      if ($token = json_decode($t, true)) {
+        if ($token['expires_in'] + $token['created'] > time()) {
+          return $t;
+        }
+      }
+    }
   }
 }

--- a/tests/OAuthHelper.php
+++ b/tests/OAuthHelper.php
@@ -30,8 +30,13 @@ $client->setRedirectUri("urn:ietf:wg:oauth:2.0:oob");
 // Visit https://code.google.com/apis/console to
 // generate your oauth2_client_id, oauth2_client_secret, and to
 // register your oauth2_redirect_uri.
-$client->setClientId("");
-$client->setClientSecret("");
+$clientId = getenv('GCLOUD_CLIENT_ID') ? getenv('GCLOUD_CLIENT_ID') : null;
+$clientSecret = getenv('GCLOUD_CLIENT_SECRET') ? getenv('GCLOUD_CLIENT_SECRET') : null;
+if (!($clientId && $clientSecret)) {
+  die("fetching a token requires GCLOUD_CLIENT_ID and GCLOUD_CLIENT_SECRET to be set\n");
+}
+$client->setClientId($clientId);
+$client->setClientSecret($clientSecret);
 
 $authUrl = $client->createAuthUrl();
 
@@ -40,6 +45,7 @@ echo "\nPlease enter the auth code:\n";
 $authCode = trim(fgets(STDIN));
 
 $accessToken = $client->authenticate($authCode);
+$file = dirname(__FILE__) . DIRECTORY_SEPARATOR . '.accessToken';
+file_put_contents($file, $accessToken);
 
-echo "\n", 'Add the following to BaseTest.php as the $token value:', "\n\n";
-echo $accessToken, "\n\n";
+echo "successfully loaded access token\n";


### PR DESCRIPTION
When an access token isn't set, the PHPunit skip message directs the user to run the oauth helper:

```bash
$ phpunit -v
# ...
27) AdSenseManagementTest::testReportsGenerate
Test requires access token
run "php tests/OAuthHelper.php"
```

The access token is stored in `tests/.accessToken` and ignored by git, so your testing does not leave modified files in your workspace.

```bash
$ php tests/OAuthHelper.php
Please enter the auth code:
4/FA7m3UKJIeBLLmf8vpnJzCTLGXYR7a521_IF-Bo_xVw
successfully loaded access token
```

When this is run, it now asks you to set `GCLOUD_CLIENT_ID` and `GCLOUD_CLIENT_SECRET` as environment variables, if these are not already set.

```
$ php tests/OAuthHelper.php
fetching a token requires GCLOUD_CLIENT_ID and GCLOUD_CLIENT_SECRET to be set
```