### PR TITLE
Leave the unrelying curl library decide what SSL version to use

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -73,8 +73,8 @@ class Google_IO_Curl extends Google_IO_Abstract
 
     curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
-    // 1 is CURL_SSLVERSION_TLSv1, which is not always defined in PHP.
-    curl_setopt($curl, CURLOPT_SSLVERSION, 1);
+    // do not set this to deprecated SSL versions, best is to use underlying library default
+    //curl_setopt($curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_DEFAULT);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_HEADER, true);
 


### PR DESCRIPTION
As discussed in case #639.