### PR TITLE
Fix Exception `Undefined variable: errorText` , code 0

### DIFF
--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -125,7 +125,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       throw new Google_Auth_Exception(
           sprintf(
               "Error fetching OAuth2 access token, message: '%s'",
-              $errorText
+              isset($errorText) ? $errorText : ''
           ),
           $response->getResponseHttpCode()
       );


### PR DESCRIPTION
Related to [this](https://github.com/google/google-api-php-client/issues/647)