### PR TITLE
Fail fast if JSON encoding fails

### DIFF
--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -115,6 +115,8 @@ class Google_Service_Resource
             $this->convertToArrayAndStripNulls($parameters['postBody']);
       }
       $postBody = json_encode($parameters['postBody']);
+      if ($postBody === false && $parameters['postBody'] !== false)
+        throw new Google_Exception("JSON encoding failed. Ensure all strings in the request are UTF-8 encoded.");
       unset($parameters['postBody']);
     }
 

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -115,8 +115,9 @@ class Google_Service_Resource
             $this->convertToArrayAndStripNulls($parameters['postBody']);
       }
       $postBody = json_encode($parameters['postBody']);
-      if ($postBody === false && $parameters['postBody'] !== false)
+      if ($postBody === false && $parameters['postBody'] !== false) {
         throw new Google_Exception("JSON encoding failed. Ensure all strings in the request are UTF-8 encoded.");
+      }
       unset($parameters['postBody']);
     }
 


### PR DESCRIPTION
Let the `call` method fail fast in case `json_encode` fails to encode the request body, rather than proceeding with invalid data (#664).