### PR TITLE
BUGFIX requiring of autoload.php in Google/Client.php

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-if (!class_exists('Google_Client')) {
-  require_once dirname(__FILE__) . '/autoload.php';
-}
+require_once dirname(__FILE__) . '/autoload.php';
+
 
 /**
  * The Google API Client


### PR DESCRIPTION
Hi Tim,

working on youtube subscription in PHP using code [here] (https://developers.google.com/youtube/v3/code_samples/php#add_a_channel_subscription) I found a bug in Google PHP API library, in src/Google/Client.php:

```
if (!class_exists('Google_Client')) {
    require_once dirname(__FILE__) . '/autoload.php';
}

class Google_Client {...}
```

The `require_once dirname(__FILE__) . '/autoload.php';` is never executed as class Google_Client is defined in this file. I have just removed the condition.

BR

Mojo