### PR TITLE
Google_Http_MediaFileUpload::chunkSize make settable

### DIFF
--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -299,4 +299,9 @@ class Google_Http_MediaFileUpload
     $this->client->getLogger()->error($error);
     throw new Google_Exception($error);
   }
+
+  public function setChunkSize($chunkSize)
+  {
+    $this->chunkSize = $chunkSize;
+  }
 }


### PR DESCRIPTION
I'm receiving chunked data with different size from some service and I would like to upload max available part of those chunks (multiple 262144 b),  but I can't set the `chunkSize` for every step of resumable upload.