### PR TITLE
Add methods to resume Uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 vendor
 examples/testfile-small.txt
 examples/testfile.txt
+tests/.accessToken

--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -126,35 +126,16 @@ class Google_Http_MediaFileUpload
   }
 
   /**
-   * Send the next part of the file to upload.
-   * @param [$chunk] the next set of bytes to send. If false will used $data passed
-   * at construct time.
-   */
-  public function nextChunk($chunk = false)
+  * Sends a PUT-Request to google drive and parses the response,
+  * setting the appropiate variables from the response()
+  *
+  * @param Google_Http_Request $httpRequest the Reuqest which will be send
+  *
+  * @return false|mixed false when the upload is unfinished or the decoded http response
+  *
+  */
+  private function makePutRequest(Google_Http_Request $httpRequest)
   {
-    if (false == $this->resumeUri) {
-      $this->resumeUri = $this->getResumeUri();
-    }
-
-    if (false == $chunk) {
-      $chunk = substr($this->data, $this->progress, $this->chunkSize);
-    }
-
-    $lastBytePos = $this->progress + strlen($chunk) - 1;
-    $headers = array(
-      'content-range' => "bytes $this->progress-$lastBytePos/$this->size",
-      'content-type' => $this->request->getRequestHeader('content-type'),
-      'content-length' => $this->chunkSize,
-      'expect' => '',
-    );
-
-    $httpRequest = new Google_Http_Request(
-        $this->resumeUri,
-        'PUT',
-        $headers,
-        $chunk
-    );
-
     if ($this->client->getClassConfig("Google_Http_Request", "enable_gzip_for_uploads")) {
       $httpRequest->enableGzip();
     } else {
@@ -185,8 +166,56 @@ class Google_Http_MediaFileUpload
   }
 
   /**
-   * @param $meta
-   * @param $params
+   * Send the next part of the file to upload.
+   * @param [$chunk] the next set of bytes to send. If false will used $data passed
+   * at construct time.
+   */
+  public function nextChunk($chunk = false)
+  {
+    if (false == $this->resumeUri) {
+      $this->resumeUri = $this->fetchResumeUri();
+    }
+
+    if (false == $chunk) {
+      $chunk = substr($this->data, $this->progress, $this->chunkSize);
+    }
+    $lastBytePos = $this->progress + strlen($chunk) - 1;
+    $headers = array(
+      'content-range' => "bytes $this->progress-$lastBytePos/$this->size",
+      'content-type' => $this->request->getRequestHeader('content-type'),
+      'content-length' => $this->chunkSize,
+      'expect' => '',
+    );
+
+    $httpRequest = new Google_Http_Request(
+        $this->resumeUri,
+        'PUT',
+        $headers,
+        $chunk
+    );
+    return $this->makePutRequest($httpRequest);
+  }
+
+  /**
+   * Resume a previously unfinished upload
+   * @param $resumeUri the resume-URI of the unfinished, resumable upload.
+   */
+  public function resume($resumeUri)
+  {
+     $this->resumeUri = $resumeUri;
+     $headers = array(
+       'content-range' => "bytes */$this->size",
+       'content-length' => 0,
+     );
+     $httpRequest = new Google_Http_Request(
+         $this->resumeUri,
+         'PUT',
+         $headers
+     );
+     return $this->makePutRequest($httpRequest);
+  }
+
+  /**
    * @return array|bool
    * @visible for testing
    */
@@ -263,7 +292,12 @@ class Google_Http_MediaFileUpload
     return self::UPLOAD_MULTIPART_TYPE;
   }
 
-  private function getResumeUri()
+  public function getResumeUri()
+  {
+    return ( $this->resumeUri !== null ? $this->resumeUri : $this->fetchResumeUri() );
+  }
+
+  private function fetchResumeUri()
   {
     $result = null;
     $body = $this->request->getPostBody();

--- a/src/Google/Service/Drive.php
+++ b/src/Google/Service/Drive.php
@@ -48,6 +48,9 @@ class Google_Service_Drive extends Google_Service
   /** View metadata for files in your Google Drive. */
   const DRIVE_METADATA_READONLY =
       "https://www.googleapis.com/auth/drive.metadata.readonly";
+  /** View the photos, videos and albums in your Google Photos. */
+  const DRIVE_PHOTOS_READONLY =
+      "https://www.googleapis.com/auth/drive.photos.readonly";
   /** View the files in your Google Drive. */
   const DRIVE_READONLY =
       "https://www.googleapis.com/auth/drive.readonly";
@@ -294,11 +297,15 @@ class Google_Service_Drive extends Google_Service
                   'type' => 'string',
                   'required' => true,
                 ),
-                'q' => array(
+                'orderBy' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
                 'pageToken' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'q' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
@@ -479,6 +486,19 @@ class Google_Service_Drive extends Google_Service
               'path' => 'files/trash',
               'httpMethod' => 'DELETE',
               'parameters' => array(),
+            ),'generateIds' => array(
+              'path' => 'files/generateIds',
+              'httpMethod' => 'GET',
+              'parameters' => array(
+                'maxResults' => array(
+                  'location' => 'query',
+                  'type' => 'integer',
+                ),
+                'space' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+              ),
             ),'get' => array(
               'path' => 'files/{fileId}',
               'httpMethod' => 'GET',
@@ -546,6 +566,10 @@ class Google_Service_Drive extends Google_Service
               'path' => 'files',
               'httpMethod' => 'GET',
               'parameters' => array(
+                'orderBy' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
                 'projection' => array(
                   'location' => 'query',
                   'type' => 'string',
@@ -584,23 +608,27 @@ class Google_Service_Drive extends Google_Service
                   'location' => 'query',
                   'type' => 'string',
                 ),
-                'updateViewedDate' => array(
+                'modifiedDateBehavior' => array(
                   'location' => 'query',
-                  'type' => 'boolean',
+                  'type' => 'string',
                 ),
                 'removeParents' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
+                'updateViewedDate' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
                 'setModifiedDate' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'convert' => array(
+                'useContentAsIndexableText' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'useContentAsIndexableText' => array(
+                'convert' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
@@ -672,23 +700,27 @@ class Google_Service_Drive extends Google_Service
                   'location' => 'query',
                   'type' => 'string',
                 ),
-                'updateViewedDate' => array(
+                'modifiedDateBehavior' => array(
                   'location' => 'query',
-                  'type' => 'boolean',
+                  'type' => 'string',
                 ),
                 'removeParents' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
+                'updateViewedDate' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
                 'setModifiedDate' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'convert' => array(
+                'useContentAsIndexableText' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
-                'useContentAsIndexableText' => array(
+                'convert' => array(
                   'location' => 'query',
                   'type' => 'boolean',
                 ),
@@ -1414,7 +1446,7 @@ class Google_Service_Drive_Changes_Resource extends Google_Service_Resource
    * @opt_param int maxResults Maximum number of changes to return.
    * @opt_param string pageToken Page token for changes.
    * @opt_param string spaces A comma-separated list of spaces to query. Supported
-   * values are 'drive' and 'appDataFolder'.
+   * values are 'drive', 'appDataFolder' and 'photos'.
    * @opt_param string startChangeId Change ID to start listing changes from.
    * @return Google_Service_Drive_ChangeList
    */
@@ -1439,7 +1471,7 @@ class Google_Service_Drive_Changes_Resource extends Google_Service_Resource
    * @opt_param int maxResults Maximum number of changes to return.
    * @opt_param string pageToken Page token for changes.
    * @opt_param string spaces A comma-separated list of spaces to query. Supported
-   * values are 'drive' and 'appDataFolder'.
+   * values are 'drive', 'appDataFolder' and 'photos'.
    * @opt_param string startChangeId Change ID to start listing changes from.
    * @return Google_Service_Drive_Channel
    */
@@ -1537,8 +1569,15 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
    * @param string $folderId The ID of the folder.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string q Query string for searching children.
+   * @opt_param string orderBy A comma-separated list of sort keys. Valid keys are
+   * 'createdDate', 'folder', 'lastViewedByMeDate', 'modifiedByMeDate',
+   * 'modifiedDate', 'quotaBytesUsed', 'recency', 'sharedWithMeDate', 'starred',
+   * and 'title'. Each key sorts ascending by default, but may be reversed with
+   * the 'desc' modifier. Example usage: ?orderBy=folder,modifiedDate desc,title.
+   * Please note that there is a current limitation for users with approximately
+   * one million files in which the requested sort order is ignored.
    * @opt_param string pageToken Page token for children.
+   * @opt_param string q Query string for searching children.
    * @opt_param int maxResults Maximum number of children to return.
    * @return Google_Service_Drive_ChildList
    */
@@ -1733,6 +1772,24 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
   }
 
   /**
+   * Generates a set of file IDs which can be provided in insert requests.
+   * (files.generateIds)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int maxResults Maximum number of IDs to return.
+   * @opt_param string space The space in which the IDs can be used to create new
+   * files. Supported values are 'drive' and 'appDataFolder'.
+   * @return Google_Service_Drive_GeneratedIds
+   */
+  public function generateIds($optParams = array())
+  {
+    $params = array();
+    $params = array_merge($params, $optParams);
+    return $this->call('generateIds', array($params), "Google_Service_Drive_GeneratedIds");
+  }
+
+  /**
    * Gets a file's metadata by ID. (files.get)
    *
    * @param string $fileId The ID for the file in question.
@@ -1789,13 +1846,20 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
    *
    * @param array $optParams Optional parameters.
    *
+   * @opt_param string orderBy A comma-separated list of sort keys. Valid keys are
+   * 'createdDate', 'folder', 'lastViewedByMeDate', 'modifiedByMeDate',
+   * 'modifiedDate', 'quotaBytesUsed', 'recency', 'sharedWithMeDate', 'starred',
+   * and 'title'. Each key sorts ascending by default, but may be reversed with
+   * the 'desc' modifier. Example usage: ?orderBy=folder,modifiedDate desc,title.
+   * Please note that there is a current limitation for users with approximately
+   * one million files in which the requested sort order is ignored.
    * @opt_param string projection This parameter is deprecated and has no
    * function.
    * @opt_param int maxResults Maximum number of files to return.
    * @opt_param string q Query string for searching files.
    * @opt_param string pageToken Page token for files.
    * @opt_param string spaces A comma-separated list of spaces to query. Supported
-   * values are 'drive' and 'appDataFolder'.
+   * values are 'drive', 'appDataFolder' and 'photos'.
    * @opt_param string corpus The body of items (files/documents) to which the
    * query applies.
    * @return Google_Service_Drive_FileList
@@ -1816,15 +1880,16 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
    * @param array $optParams Optional parameters.
    *
    * @opt_param string addParents Comma-separated list of parent IDs to add.
+   * @opt_param string modifiedDateBehavior Determines the behavior in which
+   * modifiedDate is updated. This overrides setModifiedDate.
+   * @opt_param string removeParents Comma-separated list of parent IDs to remove.
    * @opt_param bool updateViewedDate Whether to update the view date after
    * successfully updating the file.
-   * @opt_param string removeParents Comma-separated list of parent IDs to remove.
    * @opt_param bool setModifiedDate Whether to set the modified date with the
    * supplied modified date.
-   * @opt_param bool convert Whether to convert this file to the corresponding
-   * Google Docs format.
    * @opt_param bool useContentAsIndexableText Whether to use the content as
    * indexable text.
+   * @opt_param bool convert This parameter is deprecated and has no function.
    * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
    * Valid values are BCP 47 codes.
    * @opt_param bool pinned Whether to pin the new revision. A file can have a
@@ -1834,7 +1899,8 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
    * If true or not set, a new blob is created as head revision, and previous
    * unpinned revisions are preserved for a short period of time. Pinned revisions
    * are stored indefinitely, using additional storage quota, up to a maximum of
-   * 200 revisions.
+   * 200 revisions. For details on how revisions are retained, see the Drive Help
+   * Center.
    * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
    * uploads.
    * @opt_param string timedTextLanguage The language of the timed text.
@@ -1863,7 +1929,8 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
   }
 
   /**
-   * Moves a file to the trash. (files.trash)
+   * Moves a file to the trash. The currently authenticated user must own the
+   * file. (files.trash)
    *
    * @param string $fileId The ID of the file to trash.
    * @param array $optParams Optional parameters.
@@ -1898,15 +1965,16 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
    * @param array $optParams Optional parameters.
    *
    * @opt_param string addParents Comma-separated list of parent IDs to add.
+   * @opt_param string modifiedDateBehavior Determines the behavior in which
+   * modifiedDate is updated. This overrides setModifiedDate.
+   * @opt_param string removeParents Comma-separated list of parent IDs to remove.
    * @opt_param bool updateViewedDate Whether to update the view date after
    * successfully updating the file.
-   * @opt_param string removeParents Comma-separated list of parent IDs to remove.
    * @opt_param bool setModifiedDate Whether to set the modified date with the
    * supplied modified date.
-   * @opt_param bool convert Whether to convert this file to the corresponding
-   * Google Docs format.
    * @opt_param bool useContentAsIndexableText Whether to use the content as
    * indexable text.
+   * @opt_param bool convert This parameter is deprecated and has no function.
    * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
    * Valid values are BCP 47 codes.
    * @opt_param bool pinned Whether to pin the new revision. A file can have a
@@ -1916,7 +1984,8 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
    * If true or not set, a new blob is created as head revision, and previous
    * unpinned revisions are preserved for a short period of time. Pinned revisions
    * are stored indefinitely, using additional storage quota, up to a maximum of
-   * 200 revisions.
+   * 200 revisions. For details on how revisions are retained, see the Drive Help
+   * Center.
    * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
    * uploads.
    * @opt_param string timedTextLanguage The language of the timed text.
@@ -4013,6 +4082,7 @@ class Google_Service_Drive_DriveFile extends Google_Collection
   public $fileExtension;
   public $fileSize;
   public $folderColorRgb;
+  public $fullFileExtension;
   public $headRevisionId;
   public $iconLink;
   public $id;
@@ -4193,6 +4263,14 @@ class Google_Service_Drive_DriveFile extends Google_Collection
   public function getFolderColorRgb()
   {
     return $this->folderColorRgb;
+  }
+  public function setFullFileExtension($fullFileExtension)
+  {
+    $this->fullFileExtension = $fullFileExtension;
+  }
+  public function getFullFileExtension()
+  {
+    return $this->fullFileExtension;
   }
   public function setHeadRevisionId($headRevisionId)
   {
@@ -4941,6 +5019,42 @@ class Google_Service_Drive_FileList extends Google_Collection
   public function getSelfLink()
   {
     return $this->selfLink;
+  }
+}
+
+class Google_Service_Drive_GeneratedIds extends Google_Collection
+{
+  protected $collection_key = 'ids';
+  protected $internal_gapi_mappings = array(
+  );
+  public $ids;
+  public $kind;
+  public $space;
+
+
+  public function setIds($ids)
+  {
+    $this->ids = $ids;
+  }
+  public function getIds()
+  {
+    return $this->ids;
+  }
+  public function setKind($kind)
+  {
+    $this->kind = $kind;
+  }
+  public function getKind()
+  {
+    return $this->kind;
+  }
+  public function setSpace($space)
+  {
+    $this->space = $space;
+  }
+  public function getSpace()
+  {
+    return $this->space;
   }
 }
 

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -25,10 +25,8 @@ class BaseTest extends PHPUnit_Framework_TestCase
   public function __construct()
   {
     parent::__construct();
-    // Fill in a token JSON here and you can test the oauth token
-    // requiring functions.
-    // $this->token = '';
 
+    $this->token = $this->loadToken();
     $this->memcacheHost = getenv('MEMCACHE_HOST') ? getenv('MEMCACHE_HOST') : null;
     $this->memcachePort = getenv('MEMCACHE_PORT') ? getenv('MEMCACHE_PORT') : null;
   }
@@ -50,9 +48,21 @@ class BaseTest extends PHPUnit_Framework_TestCase
   public function checkToken()
   {
     if (!strlen($this->token)) {
-      $this->markTestSkipped('Test requires access token');
+      $this->markTestSkipped("Test requires access token\nrun \"php tests/OAuthHelper.php\"");
       return false;
     }
     return true;
+  }
+
+  public function loadToken()
+  {
+    if (file_exists($f = dirname(__FILE__) . DIRECTORY_SEPARATOR . '.accessToken')) {
+      $t = file_get_contents($f);
+      if ($token = json_decode($t, true)) {
+        if ($token['expires_in'] + $token['created'] > time()) {
+          return $t;
+        }
+      }
+    }
   }
 }

--- a/tests/OAuthHelper.php
+++ b/tests/OAuthHelper.php
@@ -30,8 +30,13 @@ $client->setRedirectUri("urn:ietf:wg:oauth:2.0:oob");
 // Visit https://code.google.com/apis/console to
 // generate your oauth2_client_id, oauth2_client_secret, and to
 // register your oauth2_redirect_uri.
-$client->setClientId("");
-$client->setClientSecret("");
+$clientId = getenv('GCLOUD_CLIENT_ID') ? getenv('GCLOUD_CLIENT_ID') : null;
+$clientSecret = getenv('GCLOUD_CLIENT_SECRET') ? getenv('GCLOUD_CLIENT_SECRET') : null;
+if (!($clientId && $clientSecret)) {
+  die("fetching a token requires GCLOUD_CLIENT_ID and GCLOUD_CLIENT_SECRET to be set\n");
+}
+$client->setClientId($clientId);
+$client->setClientSecret($clientSecret);
 
 $authUrl = $client->createAuthUrl();
 
@@ -40,6 +45,7 @@ echo "\nPlease enter the auth code:\n";
 $authCode = trim(fgets(STDIN));
 
 $accessToken = $client->authenticate($authCode);
+$file = dirname(__FILE__) . DIRECTORY_SEPARATOR . '.accessToken';
+file_put_contents($file, $accessToken);
 
-echo "\n", 'Add the following to BaseTest.php as the $token value:', "\n\n";
-echo $accessToken, "\n\n";
+echo "successfully loaded access token\n";


### PR DESCRIPTION
This Pull Request adds Support to resume an upload to google Drive, as asked in #658.
To achieve this, the following changes were Made:
* Renamed the `getResumeUri()`-Method to `fetchResumeUri()`, as it's more clear
* Added the Method `getResumeUri()` which is now used as a getter for the private `resumeUri`-property. 
* Added a `resume($uri)`-method to be called with an resumeUri, which will fetch the upload status & setup the object (set the resumeUri & progress properties).
* Moved code from `nextChunk()` to the new private `makePutRequest($request)` method to avoid duplicating code from `nextChunk()` in `resume()`.

With this changes, any chunked upload can be easily paused (or a better error-handling can be implemented) by simply getting the resumeURI from the `Google_Http_MediaFileUpload`-Object, storing it anywhere & later creating a new `Google_Http_MediaFileUpload`-Object with the same constructor-parameters as the original one & calling `$object->resume( $previously_stored_resumeUri);`, then proceeding with `nextChunk`. If `nextChunk` is called with chunked data, `$object->getProgress` can be used to find out the offset to be applied to the supplied data.

All informations are from [this reference](https://developers.google.com/drive/web/manage-uploads#resume-upload).