### PR TITLE
Add methods to resume Uploads

### DIFF
--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -126,35 +126,16 @@ class Google_Http_MediaFileUpload
   }
 
   /**
-   * Send the next part of the file to upload.
-   * @param [$chunk] the next set of bytes to send. If false will used $data passed
-   * at construct time.
-   */
-  public function nextChunk($chunk = false)
+  * Sends a PUT-Request to google drive and parses the response,
+  * setting the appropiate variables from the response()
+  *
+  * @param Google_Http_Request $httpRequest the Reuqest which will be send
+  *
+  * @return false|mixed false when the upload is unfinished or the decoded http response
+  *
+  */
+  private function makePutRequest(Google_Http_Request $httpRequest)
   {
-    if (false == $this->resumeUri) {
-      $this->resumeUri = $this->getResumeUri();
-    }
-
-    if (false == $chunk) {
-      $chunk = substr($this->data, $this->progress, $this->chunkSize);
-    }
-
-    $lastBytePos = $this->progress + strlen($chunk) - 1;
-    $headers = array(
-      'content-range' => "bytes $this->progress-$lastBytePos/$this->size",
-      'content-type' => $this->request->getRequestHeader('content-type'),
-      'content-length' => $this->chunkSize,
-      'expect' => '',
-    );
-
-    $httpRequest = new Google_Http_Request(
-        $this->resumeUri,
-        'PUT',
-        $headers,
-        $chunk
-    );
-
     if ($this->client->getClassConfig("Google_Http_Request", "enable_gzip_for_uploads")) {
       $httpRequest->enableGzip();
     } else {
@@ -185,8 +166,56 @@ class Google_Http_MediaFileUpload
   }
 
   /**
-   * @param $meta
-   * @param $params
+   * Send the next part of the file to upload.
+   * @param [$chunk] the next set of bytes to send. If false will used $data passed
+   * at construct time.
+   */
+  public function nextChunk($chunk = false)
+  {
+    if (false == $this->resumeUri) {
+      $this->resumeUri = $this->fetchResumeUri();
+    }
+
+    if (false == $chunk) {
+      $chunk = substr($this->data, $this->progress, $this->chunkSize);
+    }
+    $lastBytePos = $this->progress + strlen($chunk) - 1;
+    $headers = array(
+      'content-range' => "bytes $this->progress-$lastBytePos/$this->size",
+      'content-type' => $this->request->getRequestHeader('content-type'),
+      'content-length' => $this->chunkSize,
+      'expect' => '',
+    );
+
+    $httpRequest = new Google_Http_Request(
+        $this->resumeUri,
+        'PUT',
+        $headers,
+        $chunk
+    );
+    return $this->makePutRequest($httpRequest);
+  }
+
+  /**
+   * Resume a previously unfinished upload
+   * @param $resumeUri the resume-URI of the unfinished, resumable upload.
+   */
+  public function resume($resumeUri)
+  {
+     $this->resumeUri = $resumeUri;
+     $headers = array(
+       'content-range' => "bytes */$this->size",
+       'content-length' => 0,
+     );
+     $httpRequest = new Google_Http_Request(
+         $this->resumeUri,
+         'PUT',
+         $headers
+     );
+     return $this->makePutRequest($httpRequest);
+  }
+
+  /**
    * @return array|bool
    * @visible for testing
    */
@@ -263,7 +292,12 @@ class Google_Http_MediaFileUpload
     return self::UPLOAD_MULTIPART_TYPE;
   }
 
-  private function getResumeUri()
+  public function getResumeUri()
+  {
+    return ( $this->resumeUri !== null ? $this->resumeUri : $this->fetchResumeUri() );
+  }
+
+  private function fetchResumeUri()
   {
     $result = null;
     $body = $this->request->getPostBody();


### PR DESCRIPTION
This Pull Request adds Support to resume an upload to google Drive, as asked in #658.
To achieve this, the following changes were Made:
* Renamed the `getResumeUri()`-Method to `fetchResumeUri()`, as it's more clear
* Added the Method `getResumeUri()` which is now used as a getter for the private `resumeUri`-property. 
* Added a `resume($uri)`-method to be called with an resumeUri, which will fetch the upload status & setup the object (set the resumeUri & progress properties).
* Moved code from `nextChunk()` to the new private `makePutRequest($request)` method to avoid duplicating code from `nextChunk()` in `resume()`.

With this changes, any chunked upload can be easily paused (or a better error-handling can be implemented) by simply getting the resumeURI from the `Google_Http_MediaFileUpload`-Object, storing it anywhere & later creating a new `Google_Http_MediaFileUpload`-Object with the same constructor-parameters as the original one & calling `$object->resume( $previously_stored_resumeUri);`, then proceeding with `nextChunk`. If `nextChunk` is called with chunked data, `$object->getProgress` can be used to find out the offset to be applied to the supplied data.

All informations are from [this reference](https://developers.google.com/drive/web/manage-uploads#resume-upload).

(Follow-Up to the closed PR #673)