### PR TITLE
Accept documented issuers accounts.google.com and https://accounts.google.com

### DIFF
--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -32,7 +32,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
   const AUTH_TOKEN_LIFETIME_SECS = 300; // five minutes in seconds
   const MAX_TOKEN_LIFETIME_SECS = 86400; // one day in seconds
   const OAUTH2_ISSUER = 'accounts.google.com';
-  const HTTPS_OAUTH2_ISSUER = 'https://accounts.google.com';
+  const OAUTH2_ISSUER_HTTPS = 'https://accounts.google.com';
 
   /** @var Google_Auth_AssertionCredentials $assertionCredentials */
   private $assertionCredentials;
@@ -493,7 +493,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
         $id_token,
         $certs,
         $audience,
-        array(self::OAUTH2_ISSUER, self::HTTPS_OAUTH2_ISSUER)
+        array(self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS)
     );
   }
 
@@ -601,6 +601,8 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       );
     }
 
+    // support HTTP and HTTPS issuers
+    // @see https://developers.google.com/identity/sign-in/web/backend-auth
     $iss = $payload['iss'];
     if ($issuer && !in_array($iss, (array) $issuer)) {
       throw new Google_Auth_Exception(

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -489,7 +489,8 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       $audience = $this->client->getClassConfig($this, 'client_id');
     }
 
-    return $this->verifySignedJwtWithCerts($id_token, $certs, $audience, array(self::OAUTH2_ISSUER, self::HTTPS_OAUTH2_ISSUER));
+    return $this->verifySignedJwtWithCerts($id_token, $certs, $audience,
+      array(self::OAUTH2_ISSUER, self::HTTPS_OAUTH2_ISSUER));
   }
 
   /**

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -515,11 +515,6 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       $issuer = null,
       $max_expiry = null
   ) {
-    // accept multiple issuers with array.
-    $issuers = null;
-    if ($issuer) {
-      $issuers = is_array($issuer) ? $issuer : array($issuer);
-    }
     if (!$max_expiry) {
       // Set the maximum time we will accept a token for.
       $max_expiry = self::MAX_TOKEN_LIFETIME_SECS;
@@ -607,7 +602,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
     }
 
     $iss = $payload['iss'];
-    if ($issuers && !in_array($iss, $issuers)) {
+    if ($issuer && !in_array($iss, (array) $issuer)) {
       throw new Google_Auth_Exception(
           sprintf(
               "Invalid issuer, %s not in %s: %s",

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -489,8 +489,12 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       $audience = $this->client->getClassConfig($this, 'client_id');
     }
 
-    return $this->verifySignedJwtWithCerts($id_token, $certs, $audience,
-      array(self::OAUTH2_ISSUER, self::HTTPS_OAUTH2_ISSUER));
+    return $this->verifySignedJwtWithCerts(
+        $id_token,
+        $certs,
+        $audience,
+        array(self::OAUTH2_ISSUER, self::HTTPS_OAUTH2_ISSUER)
+    );
   }
 
   /**


### PR DESCRIPTION
changed to accept both issuers "accounts.google.com" and "https://accounts.google.com/"
to fix the issue #696.

https://developers.google.com/identity/sign-in/web/backend-auth
- Verify the integrity of the ID token
```
The value of iss in the ID token is equal to accounts.google.com or https://accounts.google.com.
```
