### PR TITLE
Fix #709 - Don't attempt JSON parsing if alt=media requested

### DIFF
--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -91,13 +91,13 @@ class Google_Http_REST
       ResponseInterface $response,
       RequestInterface $request = null
   ) {
-    $result = $response->json();
     $body = (string) $response->getBody();
     $code = $response->getStatusCode();
 
     // retry strategy
     if ((intVal($code)) >= 300) {
       $errors = null;
+      $result = $response->json();
       // Specific check for APIs which don't return error details, such as Blogger.
       if (isset($result['error']) && isset($result['error']['errors'])) {
         $errors = $result['error']['errors'];
@@ -110,6 +110,6 @@ class Google_Http_REST
       return $body;
     }
 
-    return $result;
+    return $response->json();
   }
 }

--- a/tests/Google/Http/RESTTest.php
+++ b/tests/Google/Http/RESTTest.php
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use GuzzleHttp\Message\Request;
 use GuzzleHttp\Message\Response;
 use GuzzleHttp\Stream\Stream;
 
@@ -46,6 +47,20 @@ class Google_HTTP_RESTTest extends BaseTest
       $this->assertEquals(array("a" => 1), $decoded);
     }
   }
+
+  public function testDecodeMediaResponse()
+  {
+    $client = $this->getClient();
+
+    $request =  new Request('GET', 'http://www.example.com?alt=media');
+    $headers = array();
+    $stream = Stream::factory('thisisnotvalidjson');
+    $response = new Response(200, $headers, $stream);
+
+    $decoded = $this->rest->decodeHttpResponse($response, $request);
+    $this->assertEquals('thisisnotvalidjson', $decoded);
+  }
+
 
   /** @expectedException Google_Service_Exception */
   public function testDecode500ResponseThrowsException()


### PR DESCRIPTION
Move JSON parsing to inside error handling and after alt=media check to prevent attempts to parse non-json content.