### PR TITLE
uses guzzle StreamHandler by default [AppEngine only]

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -27,9 +27,10 @@ use Google\Auth\UserRefreshCredentials;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Collection;
+use GuzzleHttp\Ring\Client\StreamHandler;
 use Psr\Log\LoggerInterface;
 use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
+use Monolog\Handler\StreamHandler as MonologStreamHandler;
 
 /**
  * The Google API Client
@@ -1004,7 +1005,7 @@ class Google_Client
   protected function createDefaultLogger()
   {
     $logger = new Logger('google-api-php-client');
-    $logger->pushHandler(new StreamHandler('php://stderr', Logger::NOTICE));
+    $logger->pushHandler(new MonologStreamHandler('php://stderr', Logger::NOTICE));
 
     return $logger;
   }
@@ -1034,8 +1035,13 @@ class Google_Client
   {
     $options = [
       'base_url' => $this->config->get('base_path'),
-      'defaults' => ['exceptions' => false]
+      'defaults' => ['exceptions' => false],
     ];
+
+    // set StreamHandler on AppEngine by default
+    if ($this->isAppEngine()) {
+      $options['handler']  = new StreamHandler();
+    }
 
     return new Client($options);
   }

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -216,6 +216,21 @@ class Google_ClientTest extends BaseTest
     $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
     $client = new Google_Client();
     $this->assertInstanceOf('Google_Cache_Memcache', $client->getCache());
+
+    // check Stream Handler is used
+    $http = $client->getHttpClient();
+    $class = new ReflectionClass(get_class($http));
+    $property = $class->getProperty('fsm');
+    $property->setAccessible(true);
+    $fsm = $property->getValue($http);
+
+    $class = new ReflectionClass(get_class($fsm));
+    $property = $class->getProperty('handler');
+    $property->setAccessible(true);
+    $handler = $property->getValue($fsm);
+
+    $this->assertInstanceOf('GuzzleHttp\Ring\Client\StreamHandler', $handler);
+
     unset($_SERVER['SERVER_SOFTWARE']);
   }
 


### PR DESCRIPTION
This is required for AppEngine calls to a succeed, otherwise the connection error `Curl Errno 7` is thrown.

We could only do this for when `isAppEngine` is true, but I'm a fan of as few conditional checks as possible. Are there any downsides to defaulting to this StreamHandler over Curl?