### PR TITLE
Prefer parameter definitions from API

### DIFF
--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -127,9 +127,10 @@ class Google_Service_Resource
     }
 
     $method['parameters'] = array_merge(
-        $method['parameters'],
-        $this->stackParameters
+        $this->stackParameters,
+        $method['parameters']
     );
+    
     foreach ($parameters as $key => $val) {
       if ($key != 'postBody' && ! isset($method['parameters'][$key])) {
         $this->client->getLogger()->error(


### PR DESCRIPTION
Switches the order of the array merge to not occlude parameters defined in the API. Note that this isn't a long term fix. In the particular case I found this, it was the mimeType parameter that conflicted. The method in question didn't involve media upload, so no conflict.

But it possible that at some point an API will come along where we'll need to disambiguate better.
