### PR TITLE
Don't try to convert to model if alt=media present

### DIFF
--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -130,7 +130,7 @@ class Google_Service_Resource
         $this->stackParameters,
         $method['parameters']
     );
-    
+
     foreach ($parameters as $key => $val) {
       if ($key != 'postBody' && ! isset($method['parameters'][$key])) {
         $this->client->getLogger()->error(
@@ -219,6 +219,10 @@ class Google_Service_Resource
       $upload = new Google_Http_MediaFileUpload($this->client, $request, $mimeType, $data);
     }
 
+    if (isset($parameters['alt']) && $parameters['alt']['value'] == 'media') {
+      $expected_class = null;
+    }
+    
     return $this->client->execute($request, $expected_class);
   }
 

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -203,6 +203,10 @@ class Google_Service_Resource
         ['json' => $postBody]
     );
 
+    if (isset($parameters['alt']) && $parameters['alt']['value'] == 'media') {
+      $expected_class = null;
+    }
+
     if ($this->client->shouldDefer()) {
       // @TODO find a better way to do this
       $request->setHeader('X-Php-Expected-Class', $expected_class);
@@ -219,10 +223,6 @@ class Google_Service_Resource
       $upload = new Google_Http_MediaFileUpload($this->client, $request, $mimeType, $data);
     }
 
-    if (isset($parameters['alt']) && $parameters['alt']['value'] == 'media') {
-      $expected_class = null;
-    }
-    
     return $this->client->execute($request, $expected_class);
   }
 

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -58,22 +58,26 @@ class Google_Service_ResourceTest extends PHPUnit_Framework_TestCase
     $this->service = new Test_Google_Service($this->client);
   }
 
-  public function testCallFailure()
-  {
-    $resource = new Google_Service_Resource(
-      $this->service,
-      "test",
-      "testResource",
-      array("methods" =>
-        array(
-          "testMethod" => array(
-            "parameters" => array(),
-            "path" => "method/path",
-            "httpMethod" => "POST",
+  function createResource() {
+    return new Google_Service_Resource(
+        $this->service,
+        "test",
+        "testResource",
+        array("methods" =>
+          array(
+            "testMethod" => array(
+              "parameters" => array(),
+              "path" => "method/path",
+              "httpMethod" => "POST",
+            )
           )
         )
-      )
-    );
+      );
+  }
+
+  public function testCallFailure()
+  {
+    $resource = $this->createResource();
     $this->setExpectedException(
         "Google_Exception",
         "Unknown function: test->testResource->someothermethod()"
@@ -83,42 +87,31 @@ class Google_Service_ResourceTest extends PHPUnit_Framework_TestCase
 
   public function testCall()
   {
-    $resource = new Google_Service_Resource(
-      $this->service,
-      "test",
-      "testResource",
-      array("methods" =>
-        array(
-          "testMethod" => array(
-            "parameters" => array(),
-            "path" => "method/path",
-            "httpMethod" => "POST",
-          )
-        )
-      )
-    );
+    $resource = $this->createResource();
     $request = $resource->call("testMethod", array(array()));
     $this->assertEquals("https://test.example.com/method/path", $request->getUrl());
     $this->assertEquals("POST", $request->getMethod());
   }
 
+  public function testCallWithExpectedClass()
+  {
+    $resource = $this->createResource();
+    $request = $resource->call("testMethod", array(array()), "Test_Item");
+    $this->assertEquals("Test_Item",
+                        $request->getHeader('X-Php-Expected-Class'));
+  }
+
+  public function testCallWithAltMediaIgnoresExpectedClass()
+  {
+    $resource = $this->createResource();
+    $request = $resource->call("testMethod", array(array("alt" => "media")), "Test_Item");
+    $this->assertEquals(null, $request->getHeader('X-Php-Expected-Class'));
+  }
+
   public function testCallServiceDefinedRoot()
   {
     $this->service->rootUrl = "https://sample.example.com";
-    $resource = new Google_Service_Resource(
-      $this->service,
-      "test",
-      "testResource",
-      array("methods" =>
-        array(
-          "testMethod" => array(
-            "parameters" => array(),
-            "path" => "method/path",
-            "httpMethod" => "POST",
-          )
-        )
-      )
-    );
+    $resource = $this->createResource();
     $request = $resource->call("testMethod", array(array()));
     $this->assertEquals("https://sample.example.com/method/path", $request->getUrl());
     $this->assertEquals("POST", $request->getMethod());
@@ -170,23 +163,10 @@ class Google_Service_ResourceTest extends PHPUnit_Framework_TestCase
 
   public function testAppEngineSslCerts()
   {
+    $resource = $this->createResource();
     $this->client->expects($this->once())
           ->method("isAppEngine")
           ->will($this->returnValue(true));
-    $resource = new Google_Service_Resource(
-      $this->service,
-      "test",
-      "testResource",
-      array("methods" =>
-        array(
-          "testMethod" => array(
-            "parameters" => array(),
-            "path" => "method/path",
-            "httpMethod" => "POST",
-          )
-        )
-      )
-    );
     $request = $resource->call("testMethod", array(array()));
     $this->assertEquals(
         '/etc/ca-certificates.crt',


### PR DESCRIPTION
One more fix for media downloads -- don't set the expected return class so that the raw body is returned.
