### PR TITLE
adds composer support in README and adds autoload back

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,38 @@ http://developers.google.com/api-client-library/php
 
 ## Installation ##
 
-For the latest installation and setup instructions, see [the documentation](https://developers.google.com/api-client-library/php/start/installation).
+You can use **Composer** or simply **Download the Release**
+
+### Composer
+
+The preferred method is via [composer](https://getcomposer.org). Follow the
+[installation instructions](https://getcomposer.org/doc/00-intro.md) if you do not already have
+composer installed.
+
+Once composer is installed, execute the following command in your project root to install this library:
+
+```sh
+composer require google/apiclient:^2.0.0@RC
+```
+
+Finally, be sure to include the autoloader:
+
+```php
+require_once '/path/to/your-project/vendor/autoload.php';
+```
+
+### Download the Release
+
+If you abhor using composer, you can download the package in its entirety. The [Releases](https://github.com/google/google-api-php-client/releases) page lists all stable versions. Download any file
+with the name `google-api-php-client-[RELEASE_NAME].zip` for a package including this library and its dependencies.
+
+Uncompress the zip file you download, and include the autoloader in your project:
+
+```php
+require_once '/path/to/google-api-php-client/vendor/autoload.php';
+```
+
+For additional installation and setup instructions, see [the documentation](https://developers.google.com/api-client-library/php/start/installation).
 
 ## Basic Example ##
 See the examples/ directory for examples of the key client features. You can

--- a/src/Google/autoload.php
+++ b/src/Google/autoload.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * THIS FILE IS FOR BACKWARDS COMPATIBLITY ONLY
+ *
+ * If you were not already including this file in your project, please ignore it
+ */
+
+$file = __DIR__ . '/../../vendor/autoload.php';
+
+if (!file_exists($file)) {
+  $exception = 'This library must be installed via composer or by downloading the full package.';
+  $exception .= ' See the instructions at https://github.com/google/google-api-php-client#installation.';
+  throw new Exception($exception);
+}
+
+$error = 'google-api-php-client\'s autoloader was moved to vendor/autoload.php in 2.0.0. This ';
+$error .= 'redirect will be removed in 2.1. Please adjust your code to use the new location.';
+trigger_error($error, E_USER_DEPRECATED);
+
+require_once $file;


### PR DESCRIPTION
This is to address [user concerns](http://stackoverflow.com/questions/33483326/how-do-i-use-composer-to-setup-google-api-php-client) regarding composer support. 

In addition, we will be adding a downloadable zip file to each project that includes all the dependencies, for those users who would prefer to not use composer.