### PR TITLE
Fix composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=5.4",
-        "google/auth": "dev-add-support-for-guzzle-6",
+        "google/auth": "~0.5",
         "firebase/php-jwt": "~2.0|~3.0",
         "monolog/monolog": "^1.17",
         "phpseclib/phpseclib": "~2.0",


### PR DESCRIPTION
Composer throws the error `google/apiclient dev-add-support-for-guzzle-6 requires google/auth dev-add-support-for-guzzle-6 -> no matching package found.` because the branch has now been merged on google/auth.