### PR TITLE
GAE: Removed usage of /etc/ca-certificates.crt

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1011,7 +1011,6 @@ class Google_Client
       if ($this->isAppEngine()) {
         // set StreamHandler on AppEngine by default
         $options['handler']  = new StreamHandler();
-        $options['defaults']['verify'] = '/etc/ca-certificates.crt';
       }
     } else {
       // guzzle 6

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -305,21 +305,6 @@ class Google_ClientTest extends BaseTest
     unset($_SERVER['SERVER_SOFTWARE']);
   }
 
-  public function testAppEngineVerifyConfig()
-  {
-    $this->onlyGuzzle5();
-
-    $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
-    $client = new Google_Client();
-
-    $this->assertEquals(
-      '/etc/ca-certificates.crt',
-      $client->getHttpClient()->getDefaultOption('verify')
-    );
-
-    unset($_SERVER['SERVER_SOFTWARE']);
-  }
-
   public function testJsonConfig()
   {
     // Device config


### PR DESCRIPTION
Removed a `StreamHandler` config line that caused my appengine to log a notice every time i made an api call. ("Unsupported SSL context options are set. The following options are present, but have been ignored: allow_self_signed, cafile")
The reason for this is that guzzle [sets](https://github.com/guzzle/guzzle/blob/master/src/Handler/StreamHandler.php#L347-L371) the `cafile` and `allow_self_signed` options when you use the `verify`-option and both are not supported by GAE.

Removed the config line and everything works fine now. Maybe it was needed in a past version of the GAE?