### PR TITLE
PHP 5.2.x compatibility issue

### DIFF
--- a/src/Google/autoload.php
+++ b/src/Google/autoload.php
@@ -15,18 +15,17 @@
  * limitations under the License.
  */
 
-spl_autoload_register(
-    function ($className) {
-      $classPath = explode('_', $className);
-      if ($classPath[0] != 'Google') {
-        return;
-      }
-      // Drop 'Google', and maximum class file path depth in this project is 3.
-      $classPath = array_slice($classPath, 1, 2);
-
-      $filePath = dirname(__FILE__) . '/' . implode('/', $classPath) . '.php';
-      if (file_exists($filePath)) {
-        require_once($filePath);
-      }
-    }
-);
+function google_api_php_client_autoload($className)
+{
+  $classPath = explode('_', $className);
+  if ($classPath[0] != 'Google') {
+    return;
+  }
+  // Drop 'Google', and maximum class file path depth in this project is 3.
+  $classPath = array_slice($classPath, 1, 2);
+  $filePath = dirname(__FILE__) . '/' . implode('/', $classPath) . '.php';
+  if (file_exists($filePath)) {
+    require_once($filePath);
+  }
+}
+spl_autoload_register('google_api_php_client_autoload');


### PR DESCRIPTION
To keep minimum requirements at PHP 5.2.1 or higher, anonymous functions shouldn't be used in autoload.php. Anonymous functions are not available prior to PHP 5.3.