### PR TITLE
GAE: Workaround for unsupported ssl options

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1011,7 +1011,12 @@ class Google_Client
       if ($this->isAppEngine()) {
         // set StreamHandler on AppEngine by default
         $options['handler']  = new StreamHandler();
-        $options['defaults']['verify'] = '/etc/ca-certificates.crt';
+        // we overwrite this but guzzle will do a lot of unneeded work if this is not set to false
+        $options['defaults']['verify'] = false;
+        // set ssl stream_context options to null as the AppEngine proxy takes care about this for us
+        $options['defaults']['stream_context'] = array(
+            'ssl' => null
+        );
       }
     } else {
       // guzzle 6

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -312,9 +312,25 @@ class Google_ClientTest extends BaseTest
     $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
     $client = new Google_Client();
 
-    $this->assertEquals(
-      '/etc/ca-certificates.crt',
+    $this->assertFalse(
       $client->getHttpClient()->getDefaultOption('verify')
+    );
+
+    unset($_SERVER['SERVER_SOFTWARE']);
+  }
+
+  public function testAppEngineStreamContextConfig()
+  {
+    $this->onlyGuzzle5();
+
+    $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';
+    $client = new Google_Client();
+
+    $this->assertArraySubset(
+      array(
+        'ssl' => null
+      ),
+      $client->getHttpClient()->getDefaultOption('stream_context')
     );
 
     unset($_SERVER['SERVER_SOFTWARE']);


### PR DESCRIPTION
Guzzle sets some default ssl context options that are not supported by the App Engine and are creating an error in the log every time an api gets called.
The app will still work but it makes filtering the logs for "real" errors pretty hard.

As said in the [App Engine docs](https://cloud.google.com/appengine/docs/php/urlfetch/#PHP_Secure_connections_and_HTTPS) the App Engine proxy takes care about certificate verification so we can safely set all the ssl context option to `null`.

The errors i get **without** this workaround:

    Unsupported SSL context options are set. The following options are present, but have been ignored: cafile
    Unsupported SSL context options are set. The following options are present, but have been ignored: cafile
    Unsupported SSL context options are set. The following options are present, but have been ignored: cafile