### PR TITLE
Handle exceptions correctly when using Guzzle 5

### DIFF
--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -76,7 +76,13 @@ class Google_Http_REST
       if (!$e->hasResponse()) {
         throw $e;
       }
-      $response = $e->getResponse();
+
+      $exceptionResponse = $e->getResponse();
+      if ($exceptionResponse instanceof \GuzzleHttp\Message\ResponseInterface) {
+          $exceptionResponse = $httpHandler->buildPsr7Response($e->getResponse());
+      }
+
+      $response = $exceptionResponse;
     }
 
     return self::decodeHttpResponse($response, $request, $expectedClass);


### PR DESCRIPTION
When calls cause an exception the error response is passed to `decodeHttpResponse` method directly. When using Guzzle 5, that response is not a PSR-7 response, which causes an error.

This pull requests catches that and converts it if necessary.