### PR TITLE
Incorrect @return line for Client::authorize

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -327,7 +327,7 @@ class Google_Client
    *
    * @param GuzzleHttp\ClientInterface $http the http client object.
    * @param GuzzleHttp\ClientInterface $authHttp an http client for authentication.
-   * @return GuzzleHttp\ClientInterface the http client objet
+   * @return GuzzleHttp\ClientInterface the http client object
    */
   public function authorize(ClientInterface $http = null, ClientInterface $authHttp = null)
   {

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -327,7 +327,7 @@ class Google_Client
    *
    * @param GuzzleHttp\ClientInterface $http the http client object.
    * @param GuzzleHttp\ClientInterface $authHttp an http client for authentication.
-   * @return void
+   * @return GuzzleHttp\ClientInterface the http client objet
    */
   public function authorize(ClientInterface $http = null, ClientInterface $authHttp = null)
   {


### PR DESCRIPTION
Was "@return void", whereas the authorize method does return a ClientInferface object in current release.