### PR TITLE
Make cURL proxy header calculation bug workaround configurable

### DIFF
--- a/src/Google/Config.php
+++ b/src/Google/Config.php
@@ -58,6 +58,10 @@ class Google_Config
         'Google_IO_Abstract' => array(
           'request_timeout_seconds' => 100,
         ),
+        'Google_IO_Curl' => array(
+          'disable_proxy_workaround' => false,
+          'options' => null,
+        ),
         'Google_Logger_Abstract' => array(
           'level' => 'debug',
           'log_format' => "[%datetime%] %level%: %message% %context%\n",

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -32,6 +32,9 @@ class Google_IO_Curl extends Google_IO_Abstract
 
   private $options = array();
 
+  /** @var bool $disableProxyWorkaround */
+  private $disableProxyWorkaround;
+
   public function __construct(Google_Client $client)
   {
     if (!extension_loaded('curl')) {
@@ -41,6 +44,11 @@ class Google_IO_Curl extends Google_IO_Abstract
     }
 
     parent::__construct($client);
+
+    $this->disableProxyWorkaround = $this->client->getClassConfig(
+        'Google_IO_Curl',
+        'disable_proxy_workaround'
+    );
   }
 
   /**
@@ -175,6 +183,10 @@ class Google_IO_Curl extends Google_IO_Abstract
    */
   protected function needsQuirk()
   {
+    if ($this->disableProxyWorkaround) {
+      return false;
+    }
+
     $ver = curl_version();
     $versionNum = $ver['version_number'];
     return $versionNum < Google_IO_Curl::NO_QUIRK_VERSION;


### PR DESCRIPTION
As discussed in #190, this PR adds a configuration option that is designed to be set by users with old cURL versions but where the vendor has backported a fix for the specific bug that was being worked around (again, see #190 for more detail). In that case, we need to allow users the option of disabling our workaround, since there is no reliable way to detect the presence of the fix at runtime.