### PR TITLE
Fix #806 - Enable custom umask for cache files

### DIFF
--- a/tests/Google/CacheTest.php
+++ b/tests/Google/CacheTest.php
@@ -40,6 +40,34 @@ class Google_CacheTest extends BaseTest
     $this->getSetDelete($cache);
   }
 
+  public function testFileWithDefaultMask()
+  {
+    $dir = sys_get_temp_dir() . '/google-api-php-client/tests/';
+    $cache = new Google_Cache_File($dir);
+    $cache->set('foo', 'bar');
+
+    $method = new ReflectionMethod($cache, 'getWriteableCacheFile');
+    $method->setAccessible(true);
+    $filename = $method->invoke($cache, 'foo');
+    $stat = stat($filename);
+
+    $this->assertEquals($stat['mode'] & 0777, 0600);
+  }
+
+  public function testFileWithCustomMask()
+  {
+    $dir = sys_get_temp_dir() . '/google-api-php-client/tests/';
+    $cache = new Google_Cache_File($dir, null, 07);
+    $cache->set('foo', 'bar');
+
+    $method = new ReflectionMethod($cache, 'getWriteableCacheFile');
+    $method->setAccessible(true);
+    $filename = $method->invoke($cache, 'foo');
+    $stat = stat($filename);
+
+    $this->assertEquals($stat['mode'] & 0777, 0660);
+  }
+
   public function testNull()
   {
     $cache = new Google_Cache_Null();


### PR DESCRIPTION
While #617 is well intentioned for its security concerns, it has an annoying side effect when the cache is shared between an application's CLI and Web Interface.  Unless you use the same username for Apache or PHP-FPM to access the CLI (which you shouldn't), a cache file will only be readable by whichever interface created it.  I believe this is what caused the `failed to open stream: Permission denied` error described in #806.

My solution is to add a third constructor argument to `Google_Cache_File` for setting a custom umask.  I've assigned it the default value `077` so that default permissions for files and directories will remain `0600` and `0700` respectively.