### PR TITLE
Fix listTranslations to make getTranslations work

### DIFF
--- a/src/Google/Service/Translate.php
+++ b/src/Google/Service/Translate.php
@@ -334,11 +334,11 @@ class Google_Service_Translate_TranslationsListResponse extends Google_Collectio
 
   public function setTranslations($translations)
   {
-    $this->translations = $translations;
+    $this->data['translations'] = $translations;
   }
   public function getTranslations()
   {
-    return $this->translations;
+    return $this->data['translations'];
   }
 }
 


### PR DESCRIPTION
If you make a listTranslations call you'll get a ```Google_Service_Translate_TranslationsListResponse``` back. This has a data value which is a key with "translations" array in it. 

Unfortunately these aren't returned by the getTranslations call,  you must instead use ```$translations->data['translations']```. This fixes that method so it works.