### PR TITLE
Fix large file download

### DIFF
--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -101,7 +101,6 @@ class Google_Http_REST
       RequestInterface $request = null,
       $expectedClass = null
   ) {
-    $body = (string) $response->getBody();
     $code = $response->getStatusCode();
     $result = null;
 
@@ -110,13 +109,12 @@ class Google_Http_REST
 
     // set the result to the body if it's not set to anything else
     if ($isJson) {
+      $body = (string) $response->getBody();
       $result = json_decode($body, true);
       if (null === $result && 0 !== json_last_error()) {
         // in the event of a parse error, return the raw string
         $result = $body;
       }
-    } else {
-      $result = $body;
     }
 
     // retry strategy


### PR DESCRIPTION
decodeHttpResponse() store the body response in a variable so if you try to download a large file from you Drive, it will crash with out of memory error.
Since the data is not needed for raw response, do it only when we try to json_decode().

I'm not sure of the modification since $body is used in Google_Service_Exception() in case of retry.
But with this change and #873 , i'm able to backup my Drive successfully.