### PR TITLE
Check if expires_in is set in token.

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -458,10 +458,14 @@ class Google_Client
     }
 
     // If the token is set to expire in the next 30 seconds.
-    $expired = ($created
-      + ($this->token['expires_in'] - 30)) < time();
+    if (isset($this->token['expires_in'])) {
+        $expired = ($created
+          + ($this->token['expires_in'] - 30)) < time();
 
-    return $expired;
+        return $expired;
+    }
+
+    return false;
   }
 
   public function getAuth()


### PR DESCRIPTION
This PR solves: 

```
ErrorException in Client.php line 462:
Undefined index: expires_in

in Client.php line 462
at HandleExceptions->handleError('8', 'Undefined index: expires_in', '/home/limon/www/youtube-search/vendor/google/apiclient/src/Google/Client.php', '462', array('created' => '0')) in Client.php line 462
at Google_Client->isAccessTokenExpired() in Client.php line 351
at Google_Client->authorize() in Client.php line 756
at Google_Client->execute(object(Request), 'Google_Service_YouTube_PlaylistListResponse') in Resource.php line 232
at Google_Service_Resource->call('list', array(array('part' => 'id', 'mine' => 'true')), 'Google_Service_YouTube_PlaylistListResponse') in YouTube.php line 3705
at Google_Service_YouTube_Playlists_Resource->listPlaylists('id', array('mine' => 'true')) in AuthController.php line 76
```