### PR TITLE
ExpiredException didn't have the correct namespace

### DIFF
--- a/src/Google/AccessToken/Verify.php
+++ b/src/Google/AccessToken/Verify.php
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+use Firebase\JWT\ExpiredException;
 use Google\Auth\CacheInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;

--- a/src/Google/AccessToken/Verify.php
+++ b/src/Google/AccessToken/Verify.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-use Firebase\JWT\ExpiredException;
+use Firebase\JWT\ExpiredException as ExpiredExceptionV3;
 use Google\Auth\CacheInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
@@ -107,6 +107,8 @@ class Google_AccessToken_Verify
 
         return (array) $payload;
       } catch (ExpiredException $e) {
+        return false;
+      } catch (ExpiredExceptionV3 $e) {
         return false;
       } catch (DomainException $e) {
         // continue


### PR DESCRIPTION
See issue #916.