### PR TITLE
adds callback cache

### DIFF
--- a/src/Google/AuthHandler/AuthHandlerFactory.php
+++ b/src/Google/AuthHandler/AuthHandlerFactory.php
@@ -26,15 +26,15 @@ class Google_AuthHandler_AuthHandlerFactory
    * @return Google_AuthHandler_Guzzle5AuthHandler|Google_AuthHandler_Guzzle6AuthHandler
    * @throws Exception
    */
-  public static function build($cache = null)
+  public static function build($cache = null, array $cacheConfig = [])
   {
     $version = ClientInterface::VERSION;
 
     switch ($version[0]) {
       case '5':
-        return new Google_AuthHandler_Guzzle5AuthHandler($cache);
+        return new Google_AuthHandler_Guzzle5AuthHandler($cache, $cacheConfig);
       case '6':
-        return new Google_AuthHandler_Guzzle6AuthHandler($cache);
+        return new Google_AuthHandler_Guzzle6AuthHandler($cache, $cacheConfig);
       default:
         throw new Exception('Version not supported');
     }

--- a/src/Google/AuthHandler/Guzzle5AuthHandler.php
+++ b/src/Google/AuthHandler/Guzzle5AuthHandler.php
@@ -15,14 +15,19 @@ use GuzzleHttp\ClientInterface;
 class Google_AuthHandler_Guzzle5AuthHandler
 {
   protected $cache;
+  protected $cacheConfig;
 
-  public function __construct(CacheInterface $cache = null)
+  public function __construct(CacheInterface $cache = null, array $cacheConfig = [])
   {
     $this->cache = $cache;
+    $this->cacheConfig = $cacheConfig;
   }
 
-  public function attachCredentials(ClientInterface $http, CredentialsLoader $credentials)
-  {
+  public function attachCredentials(
+      ClientInterface $http,
+      CredentialsLoader $credentials,
+      callable $tokenCallback = null
+  ) {
     // if we end up needing to make an HTTP request to retrieve credentials, we
     // can use our existing one, but we need to throw exceptions so the error
     // bubbles up.
@@ -30,8 +35,8 @@ class Google_AuthHandler_Guzzle5AuthHandler
     $authHttpHandler = HttpHandlerFactory::build($authHttp);
     $subscriber = new AuthTokenSubscriber(
         $credentials,
-        [],
-        $this->cache,
+        $this->cacheConfig,
+        new Google_Cache_Callback($tokenCallback, $this->cache),
         $authHttpHandler
     );
 
@@ -50,7 +55,7 @@ class Google_AuthHandler_Guzzle5AuthHandler
     $subscriber = new ScopedAccessTokenSubscriber(
         $tokenFunc,
         $scopes,
-        [],
+        $this->cacheConfig,
         $this->cache
     );
 

--- a/src/Google/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/Google/AuthHandler/Guzzle6AuthHandler.php
@@ -15,14 +15,19 @@ use GuzzleHttp\ClientInterface;
 class Google_AuthHandler_Guzzle6AuthHandler
 {
   protected $cache;
+  protected $cacheConfig;
 
-  public function __construct(CacheInterface $cache = null)
+  public function __construct(CacheInterface $cache = null, array $cacheConfig = [])
   {
     $this->cache = $cache;
+    $this->cacheConfig = $cacheConfig;
   }
 
-  public function attachCredentials(ClientInterface $http, CredentialsLoader $credentials)
-  {
+  public function attachCredentials(
+      ClientInterface $http,
+      CredentialsLoader $credentials,
+      callable $tokenCallback = null
+  ) {
     // if we end up needing to make an HTTP request to retrieve credentials, we
     // can use our existing one, but we need to throw exceptions so the error
     // bubbles up.
@@ -30,8 +35,8 @@ class Google_AuthHandler_Guzzle6AuthHandler
     $authHttpHandler = HttpHandlerFactory::build($authHttp);
     $middleware = new AuthTokenMiddleware(
         $credentials,
-        [],
-        $this->cache,
+        $this->cacheConfig,
+        new Google_Cache_Callback($tokenCallback, $this->cache),
         $authHttpHandler
     );
 
@@ -53,7 +58,7 @@ class Google_AuthHandler_Guzzle6AuthHandler
     $middleware = new ScopedAccessTokenMiddleware(
         $tokenFunc,
         $scopes,
-        [],
+        $this->cacheConfig,
         $this->cache
     );
 

--- a/src/Google/Cache/Callback.php
+++ b/src/Google/Cache/Callback.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Google\Auth\CacheInterface;
+
+/**
+ * In-memory cache
+ */
+class Google_Cache_Callback implements CacheInterface
+{
+  /**
+   * @var callback $callback
+   */
+  protected $callback;
+
+  /**
+   * @var Google\Auth\CacheInterface $cache
+   */
+  protected $cache;
+
+  public function __construct(callable $callback = null, CacheInterface $cache = null)
+  {
+    $this->callback = $callback;
+
+    if (is_null($cache)) {
+      $cache = new Google_Cache_Memory;
+    }
+
+    $this->cache = $cache;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function get($key, $expiration = false)
+  {
+    return $this->cache->get($key, $expiration);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function set($key, $value)
+  {
+    // notify the callback
+    if ($this->callback) {
+      $func = $this->callback;
+      $func($key, $value);
+    }
+
+    return $this->cache->set($key, $value);
+  }
+
+  /**
+   * @inheritDoc
+   * @param String $key
+   */
+  public function delete($key)
+  {
+    return $this->cache->delete($key);
+  }
+}

--- a/tests/Google/Cache/CallbackTest.php
+++ b/tests/Google/Cache/CallbackTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Google_Cache_CallbackTest extends BaseTest
+{
+  public function testCallbackCache()
+  {
+    $phpunit = $this;
+    $called = false;
+    $callback = function ($key, $value) use ($phpunit, &$called) {
+      $called = true;
+      $phpunit->assertEquals('foo', $key);
+      $phpunit->assertEquals('bar', $value);
+    };
+
+    $cache = new Google_Cache_Callback($callback);
+    $cache->set('foo', 'bar');
+
+    $this->assertTrue($called);
+  }
+
+  public function testClientNotifiesCallbackCacheByDefault()
+  {
+    $this->checkToken();
+
+    $client = $this->getClient();
+    $accessToken = $client->getAccessToken();
+
+    if (!isset($accessToken['refresh_token'])) {
+      $this->markTestSkipped('Refresh Token required');
+    }
+
+    // make the client think the token is expired
+    $accessToken['expires_in'] = 0;
+    $client->getCache()->set('access_token', $accessToken);
+
+    // ensure cache is expired cache
+    $client->setCacheConfig([ 'lifetime' => 1 ]);
+    sleep(1);
+
+    // make a silly request to obtain a new token
+    $http = $client->authorize();
+    $http->get('https://www.googleapis.com/books/v1/volumes?q=Voltaire');
+    $newToken = $client->getAccessToken();
+
+    $this->assertNotEquals($accessToken['access_token'], $newToken['access_token']);
+  }
+}


### PR DESCRIPTION
This is an alternative to #905

Essentially, we've added a callback cache that, when updated with a new token, updates the access token in `Google_Client`, so the method `$client->getAccessToken()` will always be the most recently requested token.

This will work despite what cache is used downstream (File, Memory, Etc). 

Ideally, we would rework the caching system so it's event-based and can more easily implement a variety of storages. I'll look into this as well, but at least for now we have a solution to #901 that works.