### PR TITLE
uses custom autoloader instead of classmap - much better

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,7 @@
         "squizlabs/php_codesniffer": "~2.3"
     },
     "autoload": {
-        "classmap": [
-            "src/"
-        ]
+        "files": ["src/Google/autoload.php"]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Classmaps are the anti-autoloader pattern. With the number of classes this pulls in, this is memory-intensive (every class-lookup pulls in the classmap).

We have a wonderful custom autoloader in `v1` that we should just tell composer to use. This will make everyone happy.