### PR TITLE
Add support for new "whoCanAdd" method

### DIFF
--- a/src/Google/Service/Groupssettings.php
+++ b/src/Google/Service/Groupssettings.php
@@ -177,6 +177,7 @@ class Google_Service_Groupssettings_Groups extends Google_Model
   public $sendMessageDenyNotification;
   public $showInGroupDirectory;
   public $spamModerationLevel;
+  public $whoCanAdd;
   public $whoCanContactOwner;
   public $whoCanInvite;
   public $whoCanJoin;
@@ -353,6 +354,14 @@ class Google_Service_Groupssettings_Groups extends Google_Model
   public function getSpamModerationLevel()
   {
     return $this->spamModerationLevel;
+  }
+  public function setWhoCanAdd($whoCanAdd)
+  {
+    $this->whoCanAdd = $whoCanAdd;
+  }
+  public function getWhoAdd()
+  {
+    return $this->whoCanAdd;
   }
   public function setWhoCanContactOwner($whoCanContactOwner)
   {


### PR DESCRIPTION
This adds support for the new "whoCanAdd" method, as documented on: https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups#resource-representations