### PR TITLE
Fix decoded json string contain unicode chars

### DIFF
--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -123,7 +123,7 @@ class Google_Http_REST
     $body = self::decodeBody($response, $request);
 
     if ($expectedClass = self::determineExpectedClass($expectedClass, $request)) {
-      $json = json_decode($body, true);
+      $json = json_decode(preg_replace('/\\\u([0-9a-z]{4})/', '&#x$1;', $body), true);
 
       return new $expectedClass($json);
     }


### PR DESCRIPTION
Fix decoded json string contain unicode chars
For example 
 {
    "name": "From",
    "value": "\"OneTwoTrip!\" \u003cnewsletter@onetwotrip.com\u003e"
   }

Decoded to "OneTwoTrip!", lost email address, only included name

