### PR TITLE
tag client services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.4",
         "google/auth": "0.9",
-        "google/apiclient-services": "*@dev",
+        "google/apiclient-services": "^0.5",
         "firebase/php-jwt": "~2.0|~3.0",
         "monolog/monolog": "^1.17",
         "phpseclib/phpseclib": "~2.0",


### PR DESCRIPTION
In preparation to BC changes about to be merged in https://github.com/google/google-api-php-client-services/pull/25, we will update this version of the library to depend on `google/apiclient-services:v0.5` 