### PR TITLE
Update the Google HTTP Request class to use the `arg_seperator` in the http_build_query call

### DIFF
--- a/src/Google/Http/Request.php
+++ b/src/Google/Http/Request.php
@@ -416,7 +416,7 @@ class Google_Http_Request
   {
     $str = '';
     $path = parse_url($this->getUrl(), PHP_URL_PATH) . "?" .
-        http_build_query($this->queryParams,'', '&');
+        http_build_query($this->queryParams, '', '&');
     $str .= $this->getRequestMethod() . ' ' . $path . " HTTP/1.1\n";
 
     foreach ($this->getRequestHeaders() as $key => $val) {

--- a/src/Google/Http/Request.php
+++ b/src/Google/Http/Request.php
@@ -416,7 +416,7 @@ class Google_Http_Request
   {
     $str = '';
     $path = parse_url($this->getUrl(), PHP_URL_PATH) . "?" .
-        http_build_query($this->queryParams);
+        http_build_query($this->queryParams,'', '&');
     $str .= $this->getRequestMethod() . ' ' . $path . " HTTP/1.1\n";
 
     foreach ($this->getRequestHeaders() as $key => $val) {

--- a/tests/general/RequestTest.php
+++ b/tests/general/RequestTest.php
@@ -83,7 +83,7 @@ class RequestTest extends BaseTest
       $this->assertEquals(3, count( $request->getQueryParams()));
       $this->assertEquals($url2, $request->getUrl());
       $this->assertEquals("Google_Client", $request->getExpectedClass());
-      $this->assertContains($request->getUrl(), $request->toBatchString("test"), '', true);
+      $this->assertContains('&hi=there', $request->toBatchString("test"), '', true);
       ini_set('arg_separator.output', $argSeparatorOutput);
       $url  = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my';
       $url2 = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my&hi=there';
@@ -94,6 +94,6 @@ class RequestTest extends BaseTest
       $this->assertEquals(3, count( $request->getQueryParams()));
       $this->assertEquals($url2, $request->getUrl());
       $this->assertEquals("Google_Client", $request->getExpectedClass());
-      $this->assertContains($request->getUrl(), $request->toBatchString("test"), '', true);
+      $this->assertContains('&hi=there', $request->toBatchString("test"), '', true);
   } 
 }

--- a/tests/general/RequestTest.php
+++ b/tests/general/RequestTest.php
@@ -74,14 +74,26 @@ class RequestTest extends BaseTest
       $argSeparatorOutput = ini_get('arg_separator.output');
       ini_set('arg_separator.output', '&amp;');
       // do test 
-      $url = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my';
+      $url  = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my';
       $url2 = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my&hi=there';
       $request = new Google_Http_Request($url);
       $request->setExpectedClass("Google_Client");
-      $this->assertEquals(2, count($request->getQueryParams()));
+      $this->assertEquals(2, count( $request->getQueryParams()));
       $request->setQueryParam("hi", "there");
+      $this->assertEquals(3, count( $request->getQueryParams()));
       $this->assertEquals($url2, $request->getUrl());
       $this->assertEquals("Google_Client", $request->getExpectedClass());
+      $this->assertContains($request->getUrl(), $request->toBatchString("test"), '', true);
       ini_set('arg_separator.output', $argSeparatorOutput);
+      $url  = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my';
+      $url2 = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my&hi=there';
+      $request = new Google_Http_Request($url);
+      $request->setExpectedClass("Google_Client");
+      $this->assertEquals(2, count( $request->getQueryParams()));
+      $request->setQueryParam("hi", "there");
+      $this->assertEquals(3, count( $request->getQueryParams()));
+      $this->assertEquals($url2, $request->getUrl());
+      $this->assertEquals("Google_Client", $request->getExpectedClass());
+      $this->assertContains($request->getUrl(), $request->toBatchString("test"), '', true);
   } 
 }

--- a/tests/general/RequestTest.php
+++ b/tests/general/RequestTest.php
@@ -68,4 +68,20 @@ class RequestTest extends BaseTest
     $this->assertArrayNotHasKey('accept-encoding', $request->getRequestHeaders());
     $this->assertFalse($request->canGzip());
   }
+  
+  public function testHttpBuildQuery()
+  {
+      $argSeparatorOutput = ini_get('arg_separator.output');
+      ini_set('arg_separator.output', '&amp;');
+      // do test 
+      $url = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my';
+      $url2 = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my&hi=there';
+      $request = new Google_Http_Request($url);
+      $request->setExpectedClass("Google_Client");
+      $this->assertEquals(2, count($request->getQueryParams()));
+      $request->setQueryParam("hi", "there");
+      $this->assertEquals($url2, $request->getUrl());
+      $this->assertEquals("Google_Client", $request->getExpectedClass());
+      ini_set('arg_separator.output', $argSeparatorOutput);
+  } 
 }


### PR DESCRIPTION
Solves https://github.com/google/google-api-php-client/issues/1046 for the legacy version
