### PR TITLE
Fix the approval_prompt default value documentation.

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -552,8 +552,8 @@ class Google_Client
 
   /**
    * @param string $approvalPrompt Possible values for approval_prompt include:
-   *  {@code "force"} to force the approval UI to appear. (This is the default value)
-   *  {@code "auto"} to request auto-approval when possible.
+   *  {@code "force"} to force the approval UI to appear.
+   *  {@code "auto"} to request auto-approval when possible. (This is the default value)
    */
   public function setApprovalPrompt($approvalPrompt)
   {


### PR DESCRIPTION
Fixed "setApprovalPrompt" method documentation to the code right default.

Here you can see the default value to approval_prompt is "auto": [Client.php#L129](https://github.com/google/google-api-php-client/blob/master/src/Google/Client.php#L129)