### PR TITLE
Don't distribute tests, build files etc. for composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/CONTRIBUTING.md export-ignore
+/examples export-ignore
+/phpunit.xml.dist export-ignore
+/style export-ignore
+/tests export-ignore
+/UPGRADING.md export-ignore


### PR DESCRIPTION
Don't distribute tests, build files etc. when installing with Composer with `--prefer-dist` (the default). This saves lots of bandwith and file extraction when installing dependencies with default settings.
