### PR TITLE
Reinsert refreshToken back into the payload

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -271,6 +271,9 @@ class Google_Client
     $creds = $auth->fetchAuthToken($httpHandler);
     if ($creds && isset($creds['access_token'])) {
       $creds['created'] = time();
+      if (!isset($creds['refresh_token'])) {
+        $creds['refresh_token'] = $refreshToken;
+      }
       $this->setAccessToken($creds);
     }
 


### PR DESCRIPTION
As of now, the Refresh Token must be cached and reinserted outside of the API all. This simplifies things a bit. More discussion can be found here:

https://github.com/google/google-api-php-client/issues/1064

