### PR TITLE
Improve model contructor api

### DIFF
--- a/src/Google/Collection.php
+++ b/src/Google/Collection.php
@@ -15,31 +15,31 @@ class Google_Collection extends Google_Model implements Iterator, Countable
 
   public function rewind()
   {
-    if (isset($this->modelData[$this->collection_key])
-        && is_array($this->modelData[$this->collection_key])) {
-      reset($this->modelData[$this->collection_key]);
+    if (isset($this->{$this->collection_key})
+        && is_array($this->{$this->collection_key})) {
+      reset($this->{$this->collection_key});
     }
   }
 
   public function current()
   {
     $this->coerceType($this->key());
-    if (is_array($this->modelData[$this->collection_key])) {
-      return current($this->modelData[$this->collection_key]);
+    if (is_array($this->{$this->collection_key})) {
+      return current($this->{$this->collection_key});
     }
   }
 
   public function key()
   {
-    if (isset($this->modelData[$this->collection_key])
-        && is_array($this->modelData[$this->collection_key])) {
-      return key($this->modelData[$this->collection_key]);
+    if (isset($this->{$this->collection_key})
+        && is_array($this->{$this->collection_key})) {
+      return key($this->{$this->collection_key});
     }
   }
 
   public function next()
   {
-    return next($this->modelData[$this->collection_key]);
+    return next($this->{$this->collection_key});
   }
 
   public function valid()
@@ -50,10 +50,10 @@ class Google_Collection extends Google_Model implements Iterator, Countable
 
   public function count()
   {
-    if (!isset($this->modelData[$this->collection_key])) {
+    if (!isset($this->{$this->collection_key})) {
       return 0;
     }
-    return count($this->modelData[$this->collection_key]);
+    return count($this->{$this->collection_key});
   }
 
   public function offsetExists($offset)
@@ -61,7 +61,7 @@ class Google_Collection extends Google_Model implements Iterator, Countable
     if (!is_numeric($offset)) {
       return parent::offsetExists($offset);
     }
-    return isset($this->modelData[$this->collection_key][$offset]);
+    return isset($this->{$this->collection_key}[$offset]);
   }
 
   public function offsetGet($offset)
@@ -70,7 +70,7 @@ class Google_Collection extends Google_Model implements Iterator, Countable
       return parent::offsetGet($offset);
     }
     $this->coerceType($offset);
-    return $this->modelData[$this->collection_key][$offset];
+    return $this->{$this->collection_key}[$offset];
   }
 
   public function offsetSet($offset, $value)
@@ -78,7 +78,7 @@ class Google_Collection extends Google_Model implements Iterator, Countable
     if (!is_numeric($offset)) {
       return parent::offsetSet($offset, $value);
     }
-    $this->modelData[$this->collection_key][$offset] = $value;
+    $this->{$this->collection_key}[$offset] = $value;
   }
 
   public function offsetUnset($offset)
@@ -86,16 +86,16 @@ class Google_Collection extends Google_Model implements Iterator, Countable
     if (!is_numeric($offset)) {
       return parent::offsetUnset($offset);
     }
-    unset($this->modelData[$this->collection_key][$offset]);
+    unset($this->{$this->collection_key}[$offset]);
   }
 
   private function coerceType($offset)
   {
     $typeKey = $this->keyType($this->collection_key);
-    if (isset($this->$typeKey) && !is_object($this->modelData[$this->collection_key][$offset])) {
+    if (isset($this->$typeKey) && !is_object($this->{$this->collection_key}[$offset])) {
       $type = $this->$typeKey;
-      $this->modelData[$this->collection_key][$offset] =
-          new $type($this->modelData[$this->collection_key][$offset]);
+      $this->{$this->collection_key}[$offset] =
+          new $type($this->{$this->collection_key}[$offset]);
     }
   }
 }

--- a/src/Google/Model.php
+++ b/src/Google/Model.php
@@ -104,8 +104,14 @@ class Google_Model implements ArrayAccess
         if ($dataType == 'array' || $dataType == 'map') {
           $this->$key = array();
           foreach ($val as $itemKey => $itemVal) {
-            $this->{$key}[$itemKey] = new $propertyClass($itemVal);
+            if ($itemVal instanceof $propertyClass) {
+              $this->{$key}[$itemKey] = $itemVal;
+            } else {
+              $this->{$key}[$itemKey] = new $propertyClass($itemVal);
+            }
           }
+        } elseif ($val instanceof $propertyClass) {
+          $this->$key = $val;
         } else {
           $this->$key = new $propertyClass($val);
         }

--- a/src/Google/Model.php
+++ b/src/Google/Model.php
@@ -98,8 +98,19 @@ class Google_Model implements ArrayAccess
   {
     // Hard initialise simple types, lazy load more complex ones.
     foreach ($array as $key => $val) {
-      if ( !property_exists($this, $this->keyType($key)) &&
-        property_exists($this, $key)) {
+      if (property_exists($this, $this->keyType($key))) {
+        $propertyClass = $this->{$this->keyType($key)};
+        $dataType = $this->{$this->dataType($key)};
+        if ($dataType == 'array' || $dataType == 'map') {
+          $this->$key = array();
+          foreach ($val as $itemKey => $itemVal) {
+            $this->{$key}[$itemKey] = new $propertyClass($itemVal);
+          }
+        } else {
+          $this->$key = new $propertyClass($val);
+        }
+        unset($array[$key]);
+      } elseif (property_exists($this, $key)) {
           $this->$key = $val;
           unset($array[$key]);
       } elseif (property_exists($this, $camelKey = $this->camelCase($key))) {

--- a/tests/Google/ModelTest.php
+++ b/tests/Google/ModelTest.php
@@ -159,7 +159,7 @@ class Google_ModelTest extends BaseTest
     $this->assertFalse(isset($model->foo));
   }
 
-  public function testCollection()
+  public function testCollectionWithItemsFromConstructor()
   {
     $data = json_decode(
         '{
@@ -184,5 +184,52 @@ class Google_ModelTest extends BaseTest
     }
     $this->assertEquals(4, $count);
     $this->assertEquals(1, $collection[0]->id);
+  }
+
+  public function testCollectionWithItemsFromSetter()
+  {
+    $data = json_decode(
+        '{
+           "kind": "calendar#events",
+           "id": "1234566",
+           "etag": "abcdef",
+           "totalItems": 4
+         }',
+        true
+    );
+    $collection = new Google_Service_Calendar_Events($data);
+    $collection->setItems([
+      new Google_Service_Calendar_Event(['id' => 1]),
+      new Google_Service_Calendar_Event(['id' => 2]),
+      new Google_Service_Calendar_Event(['id' => 3]),
+      new Google_Service_Calendar_Event(['id' => 4]),
+    ]);
+    $this->assertEquals(4, count($collection));
+    $count = 0;
+    foreach ($collection as $col) {
+      $count++;
+    }
+    $this->assertEquals(4, $count);
+    $this->assertEquals(1, $collection[0]->id);
+  }
+
+  public function testMapDataType()
+  {
+    $data = json_decode(
+        '{
+            "calendar": {
+              "regular":  { "background": "#FFF", "foreground": "#000" },
+              "inverted": { "background": "#000", "foreground": "#FFF" }
+            }
+         }',
+        true
+    );
+    $collection = new Google_Service_Calendar_Colors($data);
+    $this->assertEquals(2, count($collection->calendar));
+    $this->assertTrue(isset($collection->calendar['regular']));
+    $this->assertTrue(isset($collection->calendar['inverted']));
+    $this->assertInstanceOf('Google_Service_Calendar_ColorDefinition', $collection->calendar['regular']);
+    $this->assertEquals('#FFF', $collection->calendar['regular']->getBackground());
+    $this->assertEquals('#FFF', $collection->calendar['inverted']->getForeground());
   }
 }

--- a/tests/Google/ModelTest.php
+++ b/tests/Google/ModelTest.php
@@ -232,4 +232,36 @@ class Google_ModelTest extends BaseTest
     $this->assertEquals('#FFF', $collection->calendar['regular']->getBackground());
     $this->assertEquals('#FFF', $collection->calendar['inverted']->getForeground());
   }
+
+  public function testPassingInstanceInConstructor()
+  {
+    $creator = new Google_Service_Calendar_EventCreator();
+    $creator->setDisplayName('Brent Shaffer');
+    $data = [
+        "creator" => $creator
+    ];
+    $event = new Google_Service_Calendar_Event($data);
+    $this->assertInstanceOf('Google_Service_Calendar_EventCreator', $event->getCreator());
+    $this->assertEquals('Brent Shaffer', $event->creator->getDisplayName());
+  }
+
+  public function testPassingInstanceInConstructorForMap()
+  {
+    $regular = new Google_Service_Calendar_ColorDefinition();
+    $regular->setBackground('#FFF');
+    $regular->setForeground('#000');
+    $data = [
+        "calendar" => [
+            "regular" =>  $regular,
+            "inverted" => [ "background" => "#000", "foreground" => "#FFF" ],
+        ]
+    ];
+    $collection = new Google_Service_Calendar_Colors($data);
+    $this->assertEquals(2, count($collection->calendar));
+    $this->assertTrue(isset($collection->calendar['regular']));
+    $this->assertTrue(isset($collection->calendar['inverted']));
+    $this->assertInstanceOf('Google_Service_Calendar_ColorDefinition', $collection->calendar['regular']);
+    $this->assertEquals('#FFF', $collection->calendar['regular']->getBackground());
+    $this->assertEquals('#FFF', $collection->calendar['inverted']->getForeground());
+  }
 }


### PR DESCRIPTION
Makes the following array-passing in the constructor and manual class creation identical:

*\* BEFORE **

``` php
$query = new \Google_Service_Datastore_Query();

$order = new \Google_Service_Datastore_PropertyOrder(['direction' => 'descending']);
$property = new \Google_Service_Datastore_PropertyReference(['name' => 'created']);
$order->setProperty($property);
$kind = new \Google_Service_Datastore_KindExpression(['name' => self::KIND]);

$query->setOrder([$order]);
$query->setKinds([$kind]);
$query->setLimit($limit);
```

*\* AFTER **

``` php
$query = new \Google_Service_Datastore_Query([
    'order' => [
        [
            'direction' => 'descending',
            'property'  => [ 'name' => 'created' ],
        ],
    ],
    'kinds' => [
        [ 'name' => self::KIND ],
    ],
    'limit' => $limit,
]);
```
