### PR TITLE
Update composer require ^2.0 to ^2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ composer installed.
 Once composer is installed, execute the following command in your project root to install this library:
 
 ```sh
-composer require google/apiclient:^2.0
+composer require google/apiclient:^2.1
 ```
 
 Finally, be sure to include the autoloader:


### PR DESCRIPTION
Instructions to install ^2.0 is incompatible with other libraries due to google/auth version conflict. `Can only install one of: google/auth[v0.8, v0.11.1].`