### PR TITLE
Added check for if range exists when getting progress for resumable u…

### DIFF
--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -165,8 +165,11 @@ class Google_Http_MediaFileUpload
 
     if (308 == $this->httpResultCode) {
       // Track the amount uploaded.
-      $range = explode('-', $response->getHeaderLine('range'));
-      $this->progress = $range[1] + 1;
+      $range = $response->getHeaderLine('range');
+      if ($range) {
+        $range_array = explode('-', $range);
+        $this->progress = $range_array[1] + 1;
+      }
 
       // Allow for changing upload URLs.
       $location = $response->getHeaderLine('location');


### PR DESCRIPTION
As per the [resumable upload docs](https://developers.google.com/youtube/v3/guides/using_resumable_upload_protocol#Handle_Response_to_Status_Request)

> If nothing has been uploaded yet, the API response will not include the Range header.

If no data has been uploaded you will get an invalid offset 1 when trying to access $range[1]. This fix allows progress to be set only if the range exists in the response header.