### PR TITLE
Added missing is_array check

### DIFF
--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -272,14 +272,11 @@ class Google_Service_Resource
       if ($paramSpec['location'] == 'path') {
         $uriTemplateVars[$paramName] = $paramSpec['value'];
       } else if ($paramSpec['location'] == 'query') {
-        if (isset($paramSpec['repeated']) && is_array($paramSpec['value'])) {
+        if (is_array($paramSpec['value'])) {
           foreach ($paramSpec['value'] as $value) {
             $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($value));
           }
         } else {
-          if (is_array($paramSpec['value'])) {
-            $paramSpec['value'] = array_shift($paramSpec['value']);
-          }
           $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($paramSpec['value']));
         }
       }

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -277,7 +277,7 @@ class Google_Service_Resource
             $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($value));
           }
         } else {
-          if(is_array($paramSpec['value'])) {
+          if (is_array($paramSpec['value'])) {
             $paramSpec['value'] = array_shift($paramSpec['value']);
           }
           $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($paramSpec['value']));

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -277,6 +277,9 @@ class Google_Service_Resource
             $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($value));
           }
         } else {
+          if(is_array($paramSpec['value'])) {
+            $paramSpec['value'] = array_shift($paramSpec['value']);
+          }
           $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($paramSpec['value']));
         }
       }


### PR DESCRIPTION
Okay, in Resources.php, it's possible for `$paramSpec['repeated']` to not be set while `$paramSpec['value']` is an array. This causes execution to fall through to line 280 and then throw a warning on `rawurldecode($paramSpec['value'])`, which expects a string, and then the request to the API will fail.

Checking if `$paramSpec['value']` is an array and then setting it to the first element if so solves the problem.

Not sure if this is the best solution, it's just the one I'm using right now to get the thing working at all.