### PR TITLE
Add missing exception to the catch chain

### DIFF
--- a/src/Google/AccessToken/Verify.php
+++ b/src/Google/AccessToken/Verify.php
@@ -17,6 +17,7 @@
  */
 
 use Firebase\JWT\ExpiredException as ExpiredExceptionV3;
+use Firebase\JWT\SignatureInvalidException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -120,6 +121,8 @@ class Google_AccessToken_Verify
         return false;
       } catch (ExpiredExceptionV3 $e) {
         return false;
+      } catch (SignatureInvalidException $e) {
+        // continue
       } catch (DomainException $e) {
         // continue
       }


### PR DESCRIPTION
As stated by @vocoded on the issue #1279 firebase/php-jwt changed the way they report a problem with the certificate. If the signature is invalid, the verify function won't throw a `DomainException` and instead it will return `false` and then the decode function will throw a `SignatureInvalidException`. This fix adds the later exception to the catch chain so it will continue trying with other certificates.
I wasn't able to replicate the issue with a test but I try this fix on my project and it seems to had the problem fixed.

tl;dr
This fixes #1279 