### PR TITLE
Fix directory and reports stop channel urls 

### DIFF
--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -263,7 +263,6 @@ class Google_Service_Resource
     }
 
     // code for leading slash
-    $requestUrl = $this->servicePath . $restPath;
     if ($this->rootUrl) {
       if ('/' !== substr($this->rootUrl, -1) && '/' !== substr($requestUrl, 0, 1)) {
         $requestUrl = '/' . $requestUrl;

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -255,13 +255,13 @@ class Google_Service_Resource
    */
   public function createRequestUri($restPath, $params)
   {
-    // Override the default servicePath address if the $restPath use a / 
+    // Override the default servicePath address if the $restPath use a /
     if ('/' == substr($restPath, 0, 1)) {
       $requestUrl = substr($restPath, 1);
     } else {
-      $requestUrl = $this->servicePath . $restPath;      
+      $requestUrl = $this->servicePath . $restPath;
     }
-    
+
     // code for leading slash
     $requestUrl = $this->servicePath . $restPath;
     if ($this->rootUrl) {

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -255,6 +255,13 @@ class Google_Service_Resource
    */
   public function createRequestUri($restPath, $params)
   {
+    // Override the default servicePath address if the $restPath use a / 
+    if ('/' == substr($restPath, 0, 1)) {
+      $requestUrl = substr($restPath, 1);
+    } else {
+      $requestUrl = $this->servicePath . $restPath;      
+    }
+    
     // code for leading slash
     $requestUrl = $this->servicePath . $restPath;
     if ($this->rootUrl) {

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -138,12 +138,35 @@ class Google_Service_ResourceTest extends BaseTest
     $this->assertEquals("https://sample.example.com/method/path", (string) $request->getUri());
     $this->assertEquals("POST", $request->getMethod());
   }
-
+  
+  /* Some Google Service (Google_Service_Directory_Resource_Channels and Google_Service_Reports_Resource_Channels) use a different servicePath value that should override 
+  the default servicePath value, it's represented by a / before the resource path. All other Services have no / before the path*/
+  public function testCreateRequestUriForASelfDefinedServicePath()
+  {
+    $this->service->servicePath = '/admin/directory/v1/';
+    $resource = new Google_Service_Resource(
+    $this->service,
+      'test',
+      'testResource',
+      array("methods" =>
+        array(
+          'testMethod' => array(
+            'parameters' => array(),
+            'path' => '/admin/directory_v1/watch/stop',
+            'httpMethod' => 'POST',
+          )
+        )
+      )
+    );
+    $request = $resource->call('testMethod', array(array()));
+    $this->assertEquals('https://test.example.com/admin/directory_v1/watch/stop', (string) $request->getUri());
+  }
+  
   public function testCreateRequestUri()
   {
-    $restPath = "/plus/{u}";
+    $restPath = "plus/{u}";
     $service = new Google_Service($this->client);
-    $service->servicePath = "http://localhost";
+    $service->servicePath = "http://localhost/";
     $resource = new Google_Service_Resource($service, 'test', 'testResource', array());
 
     // Test Path
@@ -159,7 +182,7 @@ class Google_Service_ResourceTest extends BaseTest
     $params['u']['type'] = 'string';
     $params['u']['location'] = 'query';
     $params['u']['value'] = 'me';
-    $value = $resource->createRequestUri('/plus', $params);
+    $value = $resource->createRequestUri('plus', $params);
     $this->assertEquals("http://localhost/plus?u=me", $value);
 
     // Test Booleans
@@ -171,7 +194,7 @@ class Google_Service_ResourceTest extends BaseTest
     $this->assertEquals("http://localhost/plus/true", $value);
 
     $params['u']['location'] = 'query';
-    $value = $resource->createRequestUri('/plus', $params);
+    $value = $resource->createRequestUri('plus', $params);
     $this->assertEquals("http://localhost/plus?u=true", $value);
 
     // Test encoding
@@ -179,7 +202,7 @@ class Google_Service_ResourceTest extends BaseTest
     $params['u']['type'] = 'string';
     $params['u']['location'] = 'query';
     $params['u']['value'] = '@me/';
-    $value = $resource->createRequestUri('/plus', $params);
+    $value = $resource->createRequestUri('plus', $params);
     $this->assertEquals("http://localhost/plus?u=%40me%2F", $value);
   }
 

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -139,8 +139,12 @@ class Google_Service_ResourceTest extends BaseTest
     $this->assertEquals("POST", $request->getMethod());
   }
   
-  /* Some Google Service (Google_Service_Directory_Resource_Channels and Google_Service_Reports_Resource_Channels) use a different servicePath value that should override 
-  the default servicePath value, it's represented by a / before the resource path. All other Services have no / before the path*/
+ /**
+  * Some Google Service (Google_Service_Directory_Resource_Channels and 
+  * Google_Service_Reports_Resource_Channels) use a different servicePath value 
+  * that should override the default servicePath value, it's represented by a / 
+  * before the resource path. All other Services have no / before the path
+  */
   public function testCreateRequestUriForASelfDefinedServicePath()
   {
     $this->service->servicePath = '/admin/directory/v1/';


### PR DESCRIPTION
Report stop channel and Directory stop channel methods uses a different service path then their default class. When the lib build the full service url, the service path is duplicated.