### PR TITLE
addresse keytype conflict

### DIFF
--- a/src/Google/Collection.php
+++ b/src/Google/Collection.php
@@ -91,11 +91,10 @@ class Google_Collection extends Google_Model implements Iterator, Countable
 
   private function coerceType($offset)
   {
-    $typeKey = $this->keyType($this->collection_key);
-    if (isset($this->$typeKey) && !is_object($this->{$this->collection_key}[$offset])) {
-      $type = $this->$typeKey;
+    $keyType = $this->keyType($this->collection_key);
+    if ($keyType && !is_object($this->{$this->collection_key}[$offset])) {
       $this->{$this->collection_key}[$offset] =
-          new $type($this->{$this->collection_key}[$offset]);
+          new $keyType($this->{$this->collection_key}[$offset]);
     }
   }
 }

--- a/tests/Google/ModelTest.php
+++ b/tests/Google/ModelTest.php
@@ -264,4 +264,18 @@ class Google_ModelTest extends BaseTest
     $this->assertEquals('#FFF', $collection->calendar['regular']->getBackground());
     $this->assertEquals('#FFF', $collection->calendar['inverted']->getForeground());
   }
+
+  /**
+   * @see https://github.com/google/google-api-php-client/issues/1308
+   */
+  public function testKeyTypePropertyConflict()
+  {
+    $data = [
+        "duration" => 0,
+        "durationType" => "unknown",
+    ];
+    $creativeAsset = new Google_Service_Dfareporting_CreativeAsset($data);
+    $this->assertEquals(0, $creativeAsset->getDuration());
+    $this->assertEquals('unknown', $creativeAsset->getDurationType());
+  }
 }


### PR DESCRIPTION
Any object extending `Google_Model` looks for the property name appended with `Type` to decide if that property is a complex type. If `$property + 'Type'` exists, the library tries to instantiate a class of `$property + 'type'`.

In the case of DfaReporting, both `$duration` and `$durationType` are valid properties, and `$duration` is not a complex type. This change ensures that the classes exist before trying to create them, thus getting around the typing conflict.