### PR TITLE
Fix version for composer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ composer installed.
 Once composer is installed, execute the following command in your project root to install this library:
 
 ```sh
-composer require google/apiclient:^2.0
+composer require google/apiclient:^2.2
 ```
 
 Finally, be sure to include the autoloader:


### PR DESCRIPTION
I tryed to install this library by this follows.

```sh
composer require google/apiclient:^2.0
```

But I am not able to do.
After that I recognized the version is already updated to 2.2.
