### PR TITLE
Updated to PHPUnit 5.3.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,9 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
-
-# Test lowest dependencies on PHP 5.4
-# (Guzzle 5.2, phpseclib 0.3)
-matrix:
-  include:
-    - php: 5.4
-      env: COMPOSER_CMD="composer update --prefer-lowest" RUN_PHP_CS=true
 
 before_install:
   - composer self-update
@@ -43,4 +34,3 @@ before_script:
 script:
   - vendor/bin/phpunit
   - if [[ "$RUN_PHP_CS" == "true" ]]; then vendor/bin/phpcs src --standard=style/ruleset.xml -np; fi
-

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Google API Client Library enables you to work with Google APIs such as Googl
 This library is in Beta. We're comfortable enough with the stability and features of the library that we want you to build real production applications on it. We will make an effort to support the public and protected surface of the library and maintain backwards compatibility in the future. While we are still in Beta, we reserve the right to make incompatible changes.
 
 ## Requirements ##
-* [PHP 5.4.0 or higher](http://www.php.net/)
+* [PHP 5.6.0 or higher](http://www.php.net/)
 
 ## Google Cloud Platform APIs
 If you're looking to call the **Google Cloud Platform** APIs, you will want to use the [Google Cloud PHP](https://github.com/googlecloudplatform/google-cloud-php) library instead of this one.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "http://developers.google.com/api-client-library/php",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.6",
         "google/auth": "^1.0",
         "google/apiclient-services": "~0.13",
         "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
@@ -16,7 +16,7 @@
         "guzzlehttp/psr7": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4",
+        "phpunit/phpunit": "5.3.*",
         "squizlabs/php_codesniffer": "~2.3",
         "symfony/dom-crawler": "~2.1",
         "symfony/css-selector": "~2.1",


### PR DESCRIPTION
I've update PHPUnit to `5.3.*`, and dropped support to PHP versions `5.4` and `5.5`, as [PHPUnit 5 requires PHP `5.6`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.0.md#removed-1).

### Why dropped support for PHP versions `5.4` and `5.5`?
These versions are [no longer supported by PHP](http://php.net/supported-versions.php).

### Why PHPUnit 5.3 and not higher?
Because in 5.4, [`getMock` method was deprecated](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.4.md#changed-2), and we will need to work on that.