### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/psr7": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4",
+        "phpunit/phpunit": "~4.8.36",
         "squizlabs/php_codesniffer": "~2.3",
         "symfony/dom-crawler": "~2.1",
         "symfony/css-selector": "~2.1",

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -20,8 +20,9 @@ use Symfony\Component\DomCrawler\Crawler;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use Cache\Adapter\Filesystem\FilesystemCachePool;
+use PHPUnit\Framework\TestCase;
 
-class BaseTest extends PHPUnit_Framework_TestCase
+class BaseTest extends TestCase
 {
   private $key;
   private $client;

--- a/tests/Google/ServiceTest.php
+++ b/tests/Google/ServiceTest.php
@@ -18,6 +18,8 @@
  * under the License.
  */
 
+use PHPUnit\Framework\TestCase;
+
 class TestModel extends Google_Model
 {
   public function mapTypes($array)
@@ -36,7 +38,7 @@ class TestService extends Google_Service
   public $batchPath = 'batch/test';
 }
 
-class Google_ServiceTest extends PHPUnit_Framework_TestCase
+class Google_ServiceTest extends TestCase
 {
   public function testCreateBatch()
   {


### PR DESCRIPTION
Simplify version of #1334.

I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.