### PR TITLE
Document that not all APIs support service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ foreach ($results as $item) {
 
 > An example of this can be seen in [`examples/service-account.php`](examples/service-account.php).
 
+Some APIs
+(such as the [YouTube Data API](https://developers.google.com/youtube/v3/)) do
+not support service accounts. Check with the specific API documentation if API
+calls return unexpected 401 or 403 errors.
+
 1. Follow the instructions to [Create a Service Account](https://developers.google.com/api-client-library/php/auth/service-accounts#creatinganaccount)
 1. Download the JSON credentials
 1. Set the path to these credentials using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable:


### PR DESCRIPTION
This was a confusing onboarding experience with the YouTube API as following the SDK example for service accounts allows some, but not all [YouTube data API calls](https://developers.google.com/youtube/v3/docs/errors). Hopefully this clears things up as it sounds like other APIs including AdSense don't fully support service accounts either.