### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Google/AccessToken/VerifyTest.php
+++ b/tests/Google/AccessToken/VerifyTest.php
@@ -72,8 +72,8 @@ class Google_AccessToken_VerifyTest extends BaseTest
     $data = json_decode($jwt->urlSafeB64Decode($segments[1]));
     $verify = new Google_AccessToken_Verify($http);
     $payload = $verify->verifyIdToken($token['id_token'], $data->aud);
-    $this->assertTrue(isset($payload['sub']));
-    $this->assertTrue(strlen($payload['sub']) > 0);
+    $this->assertArrayHasKey('sub', $payload);
+    $this->assertGreaterThan(0, strlen($payload['sub']));
 
     // TODO: Need to be smart about testing/disabling the
     // caching for this test to make sense. Not sure how to do that
@@ -83,8 +83,8 @@ class Google_AccessToken_VerifyTest extends BaseTest
     $data = json_decode($jwt->urlSafeB64Decode($segments[1]));
     $verify = new Google_AccessToken_Verify($http);
     $payload = $verify->verifyIdToken($token['id_token'], $data->aud);
-    $this->assertTrue(isset($payload['sub']));
-    $this->assertTrue(strlen($payload['sub']) > 0);
+    $this->assertArrayHasKey('sub', $payload);
+    $this->assertGreaterThan(0, strlen($payload['sub']));
   }
 
   /**

--- a/tests/Google/Http/BatchTest.php
+++ b/tests/Google/Http/BatchTest.php
@@ -36,9 +36,10 @@ class Google_Http_BatchTest extends BaseTest
     $batch->add($plus->people->get('me'), 'key3');
 
     $result = $batch->execute();
-    $this->assertTrue(isset($result['response-key1']));
-    $this->assertTrue(isset($result['response-key2']));
-    $this->assertTrue(isset($result['response-key3']));
+    $this->assertArrayHasKey('response-key1', $result);
+    $this->assertArrayHasKey('response-key2', $result);
+    $this->assertArrayHasKey('response-key3', $result);
+
   }
 
   public function testBatchRequest()
@@ -53,9 +54,9 @@ class Google_Http_BatchTest extends BaseTest
     $batch->add($plus->people->get('+LarryPage'), 'key3');
 
     $result = $batch->execute();
-    $this->assertTrue(isset($result['response-key1']));
-    $this->assertTrue(isset($result['response-key2']));
-    $this->assertTrue(isset($result['response-key3']));
+    $this->assertArrayHasKey('response-key1', $result);
+    $this->assertArrayHasKey('response-key2', $result);
+    $this->assertArrayHasKey('response-key3', $result);
   }
 
   public function testBatchRequestWithPostBody()
@@ -78,9 +79,9 @@ class Google_Http_BatchTest extends BaseTest
     $batch->add($shortener->url->insert($url3), 'key3');
 
     $result = $batch->execute();
-    $this->assertTrue(isset($result['response-key1']));
-    $this->assertTrue(isset($result['response-key2']));
-    $this->assertTrue(isset($result['response-key3']));
+    $this->assertArrayHasKey('response-key1', $result);
+    $this->assertArrayHasKey('response-key2', $result);
+    $this->assertArrayHasKey('response-key3', $result);
   }
 
   public function testInvalidBatchRequest()
@@ -94,7 +95,7 @@ class Google_Http_BatchTest extends BaseTest
     $batch->add($plus->people->get('+LarryPage'), 'key2');
 
     $result = $batch->execute();
-    $this->assertTrue(isset($result['response-key2']));
+    $this->assertArrayHasKey('response-key2', $result);
     $this->assertInstanceOf(
         'Google_Service_Exception',
         $result['response-key1']

--- a/tests/Google/Http/MediaFileUploadTest.php
+++ b/tests/Google/Http/MediaFileUploadTest.php
@@ -114,7 +114,7 @@ class Google_Http_MediaFileUploadTest extends BaseTest
 
     // request the resumable url
     $uri = $media->getResumeUri();
-    $this->assertTrue(is_string($uri));
+    $this->assertInternalType('string', $uri);
 
     // parse the URL
     $parts = parse_url($uri);

--- a/tests/Google/Service/PlusTest.php
+++ b/tests/Google/Service/PlusTest.php
@@ -58,12 +58,12 @@ class Google_Service_PlusTest extends BaseTest
   {
     // assertArrayHasKey uses array_key_exists, which is not great:
     // it doesn't understand SPL ArrayAccess
-    $this->assertTrue(isset($item['actor']));
+    $this->assertArrayHasKey('actor', $item);
     $this->assertInstanceOf('Google_Service_Plus_ActivityActor', $item->actor);
     $this->assertTrue(isset($item['actor']['displayName']));
     $this->assertTrue(isset($item['actor']->url));
-    $this->assertTrue(isset($item['object']));
-    $this->assertTrue(isset($item['access']));
-    $this->assertTrue(isset($item['provider']));
+    $this->assertArrayHasKey('object', $item);
+    $this->assertArrayHasKey('access', $item);
+    $this->assertArrayHasKey('provider', $item);
   }
 }

--- a/tests/Google/Service/TasksTest.php
+++ b/tests/Google/Service/TasksTest.php
@@ -59,7 +59,7 @@ class Google_Service_TasksTest extends BaseTest
     }
 
     $tasksArray = $tasks->listTasks($list['id']);
-    $this->assertTrue(count($tasksArray) > 1);
+    $this->assertGreaterThan(1, count($tasksArray));
     foreach ($tasksArray['items'] as $task) {
       $this->assertIsTask($task);
     }

--- a/tests/examples/serviceAccountTest.php
+++ b/tests/examples/serviceAccountTest.php
@@ -28,7 +28,7 @@ class examples_serviceAccountTest extends BaseTest
     $crawler = $this->loadExample('service-account.php');
 
     $nodes = $crawler->filter('br');
-    $this->assertEquals(10, count($nodes));
+    $this->assertCount(10, $nodes);
     $this->assertContains('Life of Henry David Thoreau', $crawler->text());
   }
 }

--- a/tests/examples/simpleQueryTest.php
+++ b/tests/examples/simpleQueryTest.php
@@ -28,7 +28,7 @@ class examples_simpleQueryTest extends BaseTest
     $crawler = $this->loadExample('simple-query.php');
 
     $nodes = $crawler->filter('br');
-    $this->assertEquals(20, count($nodes));
+    $this->assertCount(20, $nodes);
 
     $nodes = $crawler->filter('h1');
     $this->assertCount(1, $nodes);


### PR DESCRIPTION
Continuing to refactory tests, like #1352, I've used:
- `assertArrayHasKey` instead of `isset` function;
- `assertGreaterThan` for mathematical comparisions;
- `assertCount` instead of `count` function;
- `assertInternalType` avoiding using `is_*` functions.