### PR TITLE
Increase minimum PHP version to 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This client library is supported but in maintenance mode only.  We are fixing ne
 The Google API Client Library enables you to work with Google APIs such as Google+, Drive, or YouTube on your server.
 
 ## Requirements ##
-* [PHP 5.4.0 or higher](http://www.php.net/)
+* [PHP 5.6.0 or higher](http://www.php.net/)
 
 ## Google Cloud Platform APIs
 If you're looking to call the **Google Cloud Platform** APIs, you will want to use the [Google Cloud PHP](https://github.com/googlecloudplatform/google-cloud-php) library instead of this one.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -244,9 +244,9 @@ $client->revokeToken($token);
 $client->isAccessTokenExpired();
 ```
 
-## PHP 5.4 is now the minimum supported PHP version
+## PHP 5.6 is now the minimum supported PHP version
 
-This was previously `PHP 5.2`. If you still need to use PHP 5.2, please continue to use
+This was previously `PHP 5.2`. If you still need to use PHP 5.5 or older, please continue to use
 the [v1-master](https://github.com/google/google-api-php-client/tree/v1-master) branch.
 
 ## Guzzle and PSR-7 are used for HTTP Requests

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "http://developers.google.com/api-client-library/php",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.6",
         "google/auth": "^1.0",
         "google/apiclient-services": "~0.13",
         "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",


### PR DESCRIPTION
Several vendor library requirements are now >=5.5.9 or ^5.5.9 and 5.5 is
unsupported by the core PHP team anyways.

Fixes #1398 