### PR TITLE
Updates footprint cq phpdoc to include string for $scopes

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -725,13 +725,13 @@ class Google_Client
   /**
    * Set the scopes to be requested. Must be called before createAuthUrl().
    * Will remove any previously configured scopes.
-   * @param array $scopes, ie: array('https://www.googleapis.com/auth/plus.login',
+   * @param string|array $scope_or_scopes, ie: array('https://www.googleapis.com/auth/plus.login',
    * 'https://www.googleapis.com/auth/moderator')
    */
-  public function setScopes($scopes)
+  public function setScopes($scope_or_scopes)
   {
     $this->requestedScopes = array();
-    $this->addScope($scopes);
+    $this->addScope($scope_or_scopes);
   }
 
   /**


### PR DESCRIPTION
Using a string is valid as the addscope() function accepts it as well.
This usage is present in the `clientTest.php` file and also in the
example from the quickstart, but currently gives out a warning on static
analysis of code, as it isn't seen as a valid input.

Resolves #1464